### PR TITLE
fix(camera+timer): FPS viewmodel + crosshair-aligned aim + clear PvP timer

### DIFF
--- a/src/ServerScriptService/MatchManager.lua
+++ b/src/ServerScriptService/MatchManager.lua
@@ -16,6 +16,12 @@ local Announcement = events:WaitForChild("Announcement")
 local PlayerEliminated = events:WaitForChild("PlayerEliminated")
 local KillFeed = events:WaitForChild("KillFeed")
 
+-- Per-shot [Fire] debug logging. Auto weapons fire ~12 shots/sec and shotguns
+-- log per pellet, so this is OFF by default to avoid flooding the console
+-- during normal play. Flip to true on the running server (or here) when
+-- debugging aim drift / hit registration. Reviewer-requested gate (#13).
+local DEBUG_FIRE_LOG = false
+
 local MatchManager = {}
 MatchManager.CurrentPhase = GameConfig.PHASE.LOBBY
 MatchManager.AlivePlayers = {}
@@ -479,10 +485,13 @@ events:WaitForChild("FireWeapon").OnServerEvent:Connect(function(player, origin,
 		local dir = (direction.Unit + spread).Unit * config.Range
 
 		local result = workspace:Raycast(origin, dir, rayParams)
-		-- Per-shot debug log so #13 (crosshair miss) can be traced post-mortem
-		print(string.format("[Fire] %s %s hit=%s",
-			player.Name, weaponName,
-			result and (result.Instance:GetFullName() .. " @ " .. tostring(result.Position)) or "MISS"))
+		-- Per-shot debug log (#13) — gated behind DEBUG_FIRE_LOG so auto-weapons
+		-- and shotguns don't flood the console during normal combat.
+		if DEBUG_FIRE_LOG then
+			print(string.format("[Fire] %s %s hit=%s",
+				player.Name, weaponName,
+				result and (result.Instance:GetFullName() .. " @ " .. tostring(result.Position)) or "MISS"))
+		end
 		if result then
 			local hitPart = result.Instance
 			local hitChar = hitPart.Parent

--- a/src/ServerScriptService/MatchManager.lua
+++ b/src/ServerScriptService/MatchManager.lua
@@ -479,6 +479,10 @@ events:WaitForChild("FireWeapon").OnServerEvent:Connect(function(player, origin,
 		local dir = (direction.Unit + spread).Unit * config.Range
 
 		local result = workspace:Raycast(origin, dir, rayParams)
+		-- Per-shot debug log so #13 (crosshair miss) can be traced post-mortem
+		print(string.format("[Fire] %s %s hit=%s",
+			player.Name, weaponName,
+			result and (result.Instance:GetFullName() .. " @ " .. tostring(result.Position)) or "MISS"))
 		if result then
 			local hitPart = result.Instance
 			local hitChar = hitPart.Parent

--- a/src/ServerScriptService/MatchManager.lua
+++ b/src/ServerScriptService/MatchManager.lua
@@ -52,6 +52,13 @@ end
 function MatchManager.setPhase(phase)
 	MatchManager.CurrentPhase = phase
 	PhaseChanged:FireAllClients(phase)
+	-- Phases without an active countdown should clear the timer label (#6).
+	-- PvE / PvPWarning push their own per-second TimerUpdate, the others don't.
+	if phase == GameConfig.PHASE.PVP
+		or phase == GameConfig.PHASE.MATCH_END
+		or phase == GameConfig.PHASE.LOBBY then
+		TimerUpdate:FireAllClients(0)
+	end
 	print("[MatchManager] Phase:", phase)
 end
 

--- a/src/ServerStorage/WeaponMeshes.lua
+++ b/src/ServerStorage/WeaponMeshes.lua
@@ -195,6 +195,18 @@ local TYPE_TO_BUILDER = {
 	Minigun = builders.Stinger,  -- placeholder
 }
 
+-- Local position of the LeftGrip attachment (relative to Handle) per weapon Type.
+-- ViewmodelController uses this to drive an IKControl that pins LeftHand to the
+-- weapon — making both hands visually grip two-handed weapons in first-person.
+-- Nil entries (Pistol, Knife) mean "single-handed, no IK".
+local LEFT_GRIP_OFFSET = {
+	SMG     = Vector3.new(0, 0.5, -1.0),   -- ~Mag area
+	Rifle   = Vector3.new(0, 0.18, -1.4),  -- on the Foregrip
+	Shotgun = Vector3.new(0, 0.32, -1.0),  -- on the Pump
+	Sniper  = Vector3.new(0, 0.5, -2.0),   -- mid-barrel
+	Minigun = Vector3.new(0, 0.5, -1.0),
+}
+
 -- Public: build(weaponName) -> Tool (Handle is the BasePart, Muzzle is an
 -- Attachment on the Handle). Wrapping as a Tool lets Roblox's built-in grip
 -- system handle the hand pose; we set Tool.Grip so the player's hand sits at
@@ -209,6 +221,16 @@ function WeaponMeshes.build(weaponName)
 		return nil
 	end
 	local model, handle = fn()
+
+	-- Add LeftGrip attachment for two-handed weapons so client IKControl can
+	-- snap the player's LeftHand to it (visual: both hands gripping the gun).
+	local leftGripOffset = LEFT_GRIP_OFFSET[cfg.Type]
+	if leftGripOffset then
+		local leftGrip = Instance.new("Attachment")
+		leftGrip.Name = "LeftGrip"
+		leftGrip.Position = leftGripOffset
+		leftGrip.Parent = handle
+	end
 
 	-- Convert Model wrapper to a Tool. Tool wants Handle as a direct child
 	-- named "Handle". Move all the model's children up into the Tool.

--- a/src/StarterPlayerScripts/CameraController.lua
+++ b/src/StarterPlayerScripts/CameraController.lua
@@ -1,0 +1,84 @@
+-- CameraController.lua (StarterPlayerScripts)
+-- Locks first-person + center-mouse during arena phases (PvE / PvPWarning / PvP).
+-- Releases to third-person free mouse in Lobby / MatchEnd.
+--
+-- Also temporarily releases the mouse cursor while shop/quest UI panels are
+-- open, so the player can actually click their buttons in first-person mode.
+-- Without this, MouseBehavior=LockCenter swallows clicks.
+--
+-- Fixes #5.
+
+local Players = game:GetService("Players")
+local UserInputService = game:GetService("UserInputService")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local RunService = game:GetService("RunService")
+
+local player = Players.LocalPlayer
+local events = ReplicatedStorage:WaitForChild("GameEvents")
+
+-- Names of GUIs that, when Enabled, should release the cursor for clicking.
+-- ScreenGui.Name on those LocalScripts.
+local INTERACTIVE_UIS = {
+	ShopUI = true,
+	DailyQuestUI = true,
+}
+
+local inArena = false  -- set true on PvE/PvPWarning/PvP, false on Lobby/MatchEnd
+
+local function isAnyInteractiveUIOpen()
+	local pg = player:FindFirstChild("PlayerGui")
+	if not pg then return false end
+	for _, gui in ipairs(pg:GetChildren()) do
+		if gui:IsA("ScreenGui") and gui.Enabled and INTERACTIVE_UIS[gui.Name] then
+			return true
+		end
+	end
+	return false
+end
+
+local function shouldLock()
+	return inArena and not isAnyInteractiveUIOpen()
+end
+
+local function applyCameraState()
+	-- CameraMode is the visual trigger; mouse state is enforced per-frame below
+	-- because the built-in CameraScript can re-lock LockCenter when CameraMode
+	-- transitions through LockFirstPerson, ignoring single-shot Default sets.
+	if shouldLock() then
+		player.CameraMode = Enum.CameraMode.LockFirstPerson
+		UserInputService.MouseIconEnabled = false
+	else
+		player.CameraMode = Enum.CameraMode.Classic
+		UserInputService.MouseIconEnabled = true
+	end
+end
+
+-- Every frame, force MouseBehavior to match shouldLock(). Cheap (one comparison
+-- + occasional assignment) and reliable against CameraScript's overrides.
+RunService.RenderStepped:Connect(function()
+	local target = shouldLock() and Enum.MouseBehavior.LockCenter or Enum.MouseBehavior.Default
+	if UserInputService.MouseBehavior ~= target then
+		UserInputService.MouseBehavior = target
+	end
+end)
+
+-- Phase changes drive arena state
+events:WaitForChild("PhaseChanged").OnClientEvent:Connect(function(phase)
+	inArena = (phase == "PvE" or phase == "PvPWarning" or phase == "PvP")
+	applyCameraState()
+end)
+
+-- Watch for shop/quest UI toggles so we release/recapture the mouse correctly.
+-- Connecting per ScreenGui (not the whole InputService) keeps the listener cheap.
+local function watchGui(gui)
+	if gui:IsA("ScreenGui") and INTERACTIVE_UIS[gui.Name] then
+		gui:GetPropertyChangedSignal("Enabled"):Connect(applyCameraState)
+	end
+end
+
+local pg = player:WaitForChild("PlayerGui")
+for _, gui in ipairs(pg:GetChildren()) do watchGui(gui) end
+pg.ChildAdded:Connect(watchGui)
+
+-- Apply initial state (we boot in lobby — third-person, free mouse)
+applyCameraState()

--- a/src/StarterPlayerScripts/CameraController.lua
+++ b/src/StarterPlayerScripts/CameraController.lua
@@ -24,6 +24,7 @@ local INTERACTIVE_UIS = {
 }
 
 local inArena = false  -- set true on PvE/PvPWarning/PvP, false on Lobby/MatchEnd
+local localEliminated = false  -- true after this player dies; cleared on next match start
 
 local function isAnyInteractiveUIOpen()
 	local pg = player:FindFirstChild("PlayerGui")
@@ -37,7 +38,9 @@ local function isAnyInteractiveUIOpen()
 end
 
 local function shouldLock()
-	return inArena and not isAnyInteractiveUIOpen()
+	-- Eliminated players spectate in third-person (#11). Phase still says PvP
+	-- because the match continues — local elimination is tracked separately.
+	return inArena and not localEliminated and not isAnyInteractiveUIOpen()
 end
 
 local function applyCameraState()
@@ -62,10 +65,23 @@ RunService.RenderStepped:Connect(function()
 	end
 end)
 
--- Phase changes drive arena state
+-- Phase changes drive arena state. PvE start of a new match clears the
+-- local-elimination flag so the player drops back into first-person.
 events:WaitForChild("PhaseChanged").OnClientEvent:Connect(function(phase)
 	inArena = (phase == "PvE" or phase == "PvPWarning" or phase == "PvP")
+	if phase == "PvE" then
+		localEliminated = false
+	end
 	applyCameraState()
+end)
+
+-- Server fires PlayerEliminated to all clients with the victim name; we only
+-- care if it's us — flip to spectator camera for the rest of the match (#11).
+events:WaitForChild("PlayerEliminated").OnClientEvent:Connect(function(victimName)
+	if victimName == player.Name then
+		localEliminated = true
+		applyCameraState()
+	end
 end)
 
 -- Watch for shop/quest UI toggles so we release/recapture the mouse correctly.

--- a/src/StarterPlayerScripts/HUDController.lua
+++ b/src/StarterPlayerScripts/HUDController.lua
@@ -15,6 +15,11 @@ local screenGui = Instance.new("ScreenGui")
 screenGui.Name = "FinalStrikeHUD"
 screenGui.ResetOnSpawn = false
 screenGui.ZIndexBehavior = Enum.ZIndexBehavior.Sibling
+-- IgnoreGuiInset=true so the crosshair at UDim2(0.5, _, 0.5, _) aligns with
+-- camera.CFrame.LookVector (real viewport center). Without this, the crosshair
+-- sits ~18px below true center because of the top-bar inset, and shots aim
+-- slightly above what the player thinks they're targeting (#13).
+screenGui.IgnoreGuiInset = true
 screenGui.Parent = player:WaitForChild("PlayerGui")
 
 -- === HP BAR ===

--- a/src/StarterPlayerScripts/HUDController.lua
+++ b/src/StarterPlayerScripts/HUDController.lua
@@ -266,20 +266,40 @@ crosshairGui.ResetOnSpawn = false
 crosshairGui.IgnoreGuiInset = true
 crosshairGui.Parent = player.PlayerGui
 
-local crosshair = Instance.new("Frame")
-crosshair.Name = "Crosshair"
-crosshair.Size = UDim2.new(0, 2, 0, 20)
-crosshair.Position = UDim2.new(0.5, -1, 0.5, -10)
-crosshair.BackgroundColor3 = Color3.fromRGB(255, 255, 255)
-crosshair.BorderSizePixel = 0
-crosshair.Parent = crosshairGui
+-- CEO-spec 4-segment open-center reticle: top/bottom/left/right white lines
+-- with a center gap. Black UIStroke outline keeps the reticle visible against
+-- bright backgrounds (sky, neon lights). Matches the reference image — gap
+-- around center, subtle black border.
+local LINE_LENGTH = 14    -- length of each arm
+local LINE_THICKNESS = 2
+local CENTER_GAP = 6      -- pixels from screen center to inner end of each arm
 
-local crosshairH = Instance.new("Frame")
-crosshairH.Size = UDim2.new(0, 20, 0, 2)
-crosshairH.Position = UDim2.new(0.5, -10, 0.5, -1)
-crosshairH.BackgroundColor3 = Color3.fromRGB(255, 255, 255)
-crosshairH.BorderSizePixel = 0
-crosshairH.Parent = crosshairGui
+local function makeReticleLine(name, size, position)
+	local line = Instance.new("Frame")
+	line.Name = name
+	line.Size = size
+	line.Position = position
+	line.BackgroundColor3 = Color3.fromRGB(255, 255, 255)
+	line.BorderSizePixel = 0
+	line.Parent = crosshairGui
+	local stroke = Instance.new("UIStroke")
+	stroke.Color = Color3.fromRGB(0, 0, 0)
+	stroke.Thickness = 1
+	stroke.Parent = line
+end
+
+makeReticleLine("ReticleTop",
+	UDim2.new(0, LINE_THICKNESS, 0, LINE_LENGTH),
+	UDim2.new(0.5, -math.floor(LINE_THICKNESS/2), 0.5, -CENTER_GAP - LINE_LENGTH))
+makeReticleLine("ReticleBottom",
+	UDim2.new(0, LINE_THICKNESS, 0, LINE_LENGTH),
+	UDim2.new(0.5, -math.floor(LINE_THICKNESS/2), 0.5, CENTER_GAP))
+makeReticleLine("ReticleLeft",
+	UDim2.new(0, LINE_LENGTH, 0, LINE_THICKNESS),
+	UDim2.new(0.5, -CENTER_GAP - LINE_LENGTH, 0.5, -math.floor(LINE_THICKNESS/2)))
+makeReticleLine("ReticleRight",
+	UDim2.new(0, LINE_LENGTH, 0, LINE_THICKNESS),
+	UDim2.new(0.5, CENTER_GAP, 0.5, -math.floor(LINE_THICKNESS/2)))
 
 -- ====== EVENT HANDLERS ======
 events:WaitForChild("HealthUpdate").OnClientEvent:Connect(function(hp, maxHP)

--- a/src/StarterPlayerScripts/HUDController.lua
+++ b/src/StarterPlayerScripts/HUDController.lua
@@ -11,15 +11,13 @@ local player = Players.LocalPlayer
 local events = ReplicatedStorage:WaitForChild("GameEvents")
 
 -- ====== CREATE HUD ======
+-- Main HUD ScreenGui keeps the default IgnoreGuiInset=false so existing widgets
+-- (HP bar at bottom, alive count + currency at top, kill feed, announcement, etc.)
+-- stay in their authored positions relative to the inset-aware coordinate space.
 local screenGui = Instance.new("ScreenGui")
 screenGui.Name = "FinalStrikeHUD"
 screenGui.ResetOnSpawn = false
 screenGui.ZIndexBehavior = Enum.ZIndexBehavior.Sibling
--- IgnoreGuiInset=true so the crosshair at UDim2(0.5, _, 0.5, _) aligns with
--- camera.CFrame.LookVector (real viewport center). Without this, the crosshair
--- sits ~18px below true center because of the top-bar inset, and shots aim
--- slightly above what the player thinks they're targeting (#13).
-screenGui.IgnoreGuiInset = true
 screenGui.Parent = player:WaitForChild("PlayerGui")
 
 -- === HP BAR ===
@@ -255,20 +253,33 @@ local function showWinner(text)
 end
 
 -- === CROSSHAIR ===
+-- Lives in its own ScreenGui with IgnoreGuiInset=true so the crosshair at
+-- UDim2(0.5, _, 0.5, _) lines up with camera.CFrame.LookVector (real viewport
+-- center). Without this, the crosshair sits ~18px below true center because of
+-- the top-bar inset, and shots aim slightly above what the player thinks they
+-- are targeting (#13). Kept in a separate ScreenGui so the inset adjustment
+-- doesn't affect the rest of the HUD layout (which is authored against the
+-- inset-aware coordinate space).
+local crosshairGui = Instance.new("ScreenGui")
+crosshairGui.Name = "FinalStrikeCrosshair"
+crosshairGui.ResetOnSpawn = false
+crosshairGui.IgnoreGuiInset = true
+crosshairGui.Parent = player.PlayerGui
+
 local crosshair = Instance.new("Frame")
 crosshair.Name = "Crosshair"
 crosshair.Size = UDim2.new(0, 2, 0, 20)
 crosshair.Position = UDim2.new(0.5, -1, 0.5, -10)
 crosshair.BackgroundColor3 = Color3.fromRGB(255, 255, 255)
 crosshair.BorderSizePixel = 0
-crosshair.Parent = screenGui
+crosshair.Parent = crosshairGui
 
 local crosshairH = Instance.new("Frame")
 crosshairH.Size = UDim2.new(0, 20, 0, 2)
 crosshairH.Position = UDim2.new(0.5, -10, 0.5, -1)
 crosshairH.BackgroundColor3 = Color3.fromRGB(255, 255, 255)
 crosshairH.BorderSizePixel = 0
-crosshairH.Parent = screenGui
+crosshairH.Parent = crosshairGui
 
 -- ====== EVENT HANDLERS ======
 events:WaitForChild("HealthUpdate").OnClientEvent:Connect(function(hp, maxHP)

--- a/src/StarterPlayerScripts/HUDController.lua
+++ b/src/StarterPlayerScripts/HUDController.lua
@@ -297,9 +297,15 @@ events:WaitForChild("PhaseChanged").OnClientEvent:Connect(function(phase)
 end)
 
 events:WaitForChild("TimerUpdate").OnClientEvent:Connect(function(seconds)
-	local min = math.floor(seconds / 60)
-	local sec = seconds % 60
-	timerLabel.Text = string.format("%d:%02d", min, sec)
+	-- Server sends 0 to mean "no active countdown" (e.g. PvP phase has no time
+	-- limit) — clear the label instead of showing 0:00 (#6).
+	if seconds <= 0 then
+		timerLabel.Text = ""
+	else
+		local min = math.floor(seconds / 60)
+		local sec = seconds % 60
+		timerLabel.Text = string.format("%d:%02d", min, sec)
+	end
 end)
 
 events:WaitForChild("Announcement").OnClientEvent:Connect(function(msg)

--- a/src/StarterPlayerScripts/ViewmodelController.lua
+++ b/src/StarterPlayerScripts/ViewmodelController.lua
@@ -42,6 +42,9 @@ local function ensureLeftHandIK(char, tool)
 	ik.EndEffector = leftHand
 	ik.Target = leftGrip  -- IKControl accepts Attachment targets
 	ik.Weight = 1.0
+	-- High Priority so the jump animation's LeftArm tracks don't override the
+	-- grip pose — without this, hand pops off the gun mid-jump (#12).
+	ik.Priority = 1000
 	ik.Parent = humanoid
 end
 

--- a/src/StarterPlayerScripts/ViewmodelController.lua
+++ b/src/StarterPlayerScripts/ViewmodelController.lua
@@ -1,0 +1,91 @@
+-- ViewmodelController.lua (StarterPlayerScripts)
+-- First-person quality-of-life for the FPS view (#5):
+--   1. Force arms visible — LockFirstPerson hides body parts via
+--      LocalTransparencyModifier; we re-set arms to 0 each frame so the
+--      player sees their own hands holding the gun.
+--   2. LeftHand IK — when a Tool with a LeftGrip attachment is equipped, an
+--      IKControl pins the LeftHand to that attachment so both hands appear
+--      to grip the weapon (Pistol/Knife are single-handed and skip this).
+
+local Players = game:GetService("Players")
+local RunService = game:GetService("RunService")
+
+local player = Players.LocalPlayer
+
+local ARM_PARTS = {
+	"LeftUpperArm", "LeftLowerArm", "LeftHand",
+	"RightUpperArm", "RightLowerArm", "RightHand",
+}
+
+local function ensureLeftHandIK(char, tool)
+	local humanoid = char:FindFirstChildOfClass("Humanoid")
+	if not humanoid then return end
+
+	-- Tear down any previous IK before setting up new one
+	local existing = humanoid:FindFirstChild("LeftHandIK")
+	if existing then existing:Destroy() end
+
+	if not tool then return end
+	local handle = tool:FindFirstChild("Handle")
+	if not handle then return end
+	local leftGrip = handle:FindFirstChild("LeftGrip")
+	if not leftGrip or not leftGrip:IsA("Attachment") then return end
+
+	local leftHand = char:FindFirstChild("LeftHand")
+	local leftUpperArm = char:FindFirstChild("LeftUpperArm")
+	if not leftHand or not leftUpperArm then return end
+
+	local ik = Instance.new("IKControl")
+	ik.Name = "LeftHandIK"
+	ik.Type = Enum.IKControlType.Position
+	ik.ChainRoot = leftUpperArm
+	ik.EndEffector = leftHand
+	ik.Target = leftGrip  -- IKControl accepts Attachment targets
+	ik.Weight = 1.0
+	ik.Parent = humanoid
+end
+
+local function watchCharacter(char)
+	-- Cache arm refs once
+	local arms = {}
+	for _, name in ipairs(ARM_PARTS) do
+		local p = char:WaitForChild(name, 5)
+		if p then table.insert(arms, p) end
+	end
+
+	-- Force arms visible every frame in first-person.
+	-- (CameraScript sets LocalTransparencyModifier=1 on body parts under
+	-- LockFirstPerson; we override the arms back to 0 here.)
+	local conn = RunService.RenderStepped:Connect(function()
+		if player.CameraMode == Enum.CameraMode.LockFirstPerson then
+			for _, p in ipairs(arms) do
+				p.LocalTransparencyModifier = 0
+			end
+		end
+	end)
+	-- Disconnect when this character despawns
+	char.AncestryChanged:Connect(function(_, parent)
+		if not parent then conn:Disconnect() end
+	end)
+
+	-- Tool equip/unequip → rebuild IKControl
+	char.ChildAdded:Connect(function(c)
+		if c:IsA("Tool") then
+			task.wait(0.1)  -- let server's grip weld settle before resolving attachments
+			ensureLeftHandIK(char, c)
+		end
+	end)
+	char.ChildRemoved:Connect(function(c)
+		if c:IsA("Tool") then ensureLeftHandIK(char, nil) end
+	end)
+
+	-- Apply to any tool already equipped on character init (e.g. respawn into match)
+	local existingTool = char:FindFirstChildOfClass("Tool")
+	if existingTool then
+		task.wait(0.1)
+		ensureLeftHandIK(char, existingTool)
+	end
+end
+
+if player.Character then watchCharacter(player.Character) end
+player.CharacterAdded:Connect(watchCharacter)

--- a/src/StarterPlayerScripts/WeaponClient.lua
+++ b/src/StarterPlayerScripts/WeaponClient.lua
@@ -94,18 +94,21 @@ local function fireWeapon()
 	-- Two-stage aim (fixes #8): the muzzle is offset from the camera (right
 	-- hand vs head/eye position), so firing FROM muzzle along the camera's ray
 	-- direction puts shots noticeably off the crosshair. Instead:
-	--   1. Cast from the camera along the screen-pointer ray to find what the
-	--      crosshair is actually over (or a far point if it hits nothing).
-	--   2. Aim from the muzzle TOWARD that point — bullets now follow the
-	--      crosshair regardless of muzzle offset.
-	local screenRay = camera:ScreenPointToRay(mouse.X, mouse.Y)
+	--   1. Cast from the camera along its forward vector to find what the
+	--      crosshair is over (camera.CFrame.LookVector is always exactly the
+	--      crosshair direction — more reliable than mouse.X/Y which can be
+	--      off-by-GuiInset in first-person LockCenter mode).
+	--   2. Aim from the muzzle TOWARD that point — bullets follow the crosshair
+	--      regardless of muzzle offset.
+	local cameraOrigin = camera.CFrame.Position
+	local cameraDir = camera.CFrame.LookVector
 	local aimParams = RaycastParams.new()
 	aimParams.FilterType = Enum.RaycastFilterType.Exclude
 	aimParams.FilterDescendantsInstances = { character }
 	local maxRange = config.Range or 500
-	local aimResult = workspace:Raycast(screenRay.Origin, screenRay.Direction * maxRange, aimParams)
+	local aimResult = workspace:Raycast(cameraOrigin, cameraDir * maxRange, aimParams)
 	local targetPos = aimResult and aimResult.Position
-		or (screenRay.Origin + screenRay.Direction * maxRange)
+		or (cameraOrigin + cameraDir * maxRange)
 	local direction = (targetPos - origin).Unit
 
 	-- Local muzzle flash for the local player (server's WeaponHit handles the


### PR DESCRIPTION
## Summary
Two fixes from CEO playtest feedback after PR #7 shipped.

Closes #5, closes #6.

## #6 — PvP timer freeze
PvP phase has no countdown loop, so the timer label stayed frozen on the last value from PvP Warning. `setPhase()` now fires `TimerUpdate(0)` for any phase without an active countdown (PvP / MatchEnd / Lobby), and `HUDController` hides the label when seconds≤0.

## #5 — FPS viewmodel (3 layers)
- **`CameraController.lua`** (new) — locks first-person on arena phases, releases to third-person free-mouse in Lobby/MatchEnd, releases the cursor while ShopUI/DailyQuestUI is open. MouseBehavior is enforced per-frame via RenderStepped because the built-in CameraScript re-locks LockCenter when CameraMode transitions through LockFirstPerson; single-shot Default sets are ignored. **All 4 states verified** (Lobby / Arena / ShopOpen / ShopClosed) via execute_luau snapshot.
- **`ViewmodelController.lua`** (new) — keeps arms visible in first-person (overrides `LocalTransparencyModifier` each frame). Creates an `IKControl` on Humanoid that pins LeftHand to the weapon's `LeftGrip` attachment so two-handed weapons appear gripped by both hands. Pistol/Knife are single-handed and skip IK.
- **`WeaponMeshes.lua`** — adds `LeftGrip` Attachment per weapon Type via `LEFT_GRIP_OFFSET` map. Position chosen to land on foregrip / pump / mag / mid-barrel of the existing mesh.

## Bonus — bullet/crosshair alignment
`WeaponClient` now uses `camera.CFrame.LookVector` instead of `camera:ScreenPointToRay(mouse.X, mouse.Y)`. LookVector always points exactly through the crosshair; mouse coords can be off by GuiInset under LockCenter, leading to subtle bullet drift even after the two-stage aim from #8. Confirmed by playtest feedback ("子彈射出去要對齊十字準星").

## Test plan
- [x] Camera state machine: Lobby/Arena/ShopOpen/ShopClosed all verified ([Classic, Default, true] / [LockFirstPerson, LockCenter, false] / [Classic, Default, true] / [LockFirstPerson, LockCenter, false])
- [x] Arms visible in first-person: `LeftHand.LocalTransparencyModifier=0` confirmed in arena
- [x] PvP timer: `setPhase(PVP)` fires `TimerUpdate(0)`; HUDController clears label
- [x] Pistol skips IK (no LeftGrip attachment created): verified Viper Mk1 has no LeftGrip
- [ ] **End-to-end IK on 2-hand weapon**: please buy a Phantom Ranger (Rifle, 1500 coins) and confirm both hands grip the weapon in first-person. Logic is sound (Type → LEFT_GRIP_OFFSET → Attachment → ensureLeftHandIK → IKControl on Humanoid) but I couldn't get a 2-hand weapon equipped via execute_luau without DataStore API access.

## Files
- 2 new (`CameraController.lua`, `ViewmodelController.lua`)
- 4 modified (`MatchManager`, `HUDController`, `WeaponClient`, `WeaponMeshes`)
- +223 / -10 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)