### PR TITLE
feat(combat): HP reset on death + 5-min PvP timer + NPC weapons

### DIFF
--- a/src/ReplicatedStorage/GameConfig.lua
+++ b/src/ReplicatedStorage/GameConfig.lua
@@ -7,7 +7,8 @@ local GameConfig = {}
 GameConfig.MIN_PLAYERS = 1          -- 1 for testing, change to 2+ for production
 GameConfig.MAX_PLAYERS = 12
 GameConfig.PVE_DURATION = 180       -- seconds
-GameConfig.PVP_COUNTDOWN = 10       -- seconds
+GameConfig.PVP_COUNTDOWN = 10       -- seconds (warning before PvP starts)
+GameConfig.PVP_DURATION = 300       -- seconds (5 min PvP cap; ends with current alive winner)
 GameConfig.LOBBY_COUNTDOWN = 10     -- seconds before match starts
 GameConfig.SPAWN_PROTECTION = 3     -- seconds of NPC-damage immunity after teleport to arena
 

--- a/src/ServerScriptService/GameEventsBootstrap.lua
+++ b/src/ServerScriptService/GameEventsBootstrap.lua
@@ -47,6 +47,7 @@ makeRemoteEvent("AmmoUpdate")         -- server → client: current, max
 -- NPC
 makeRemoteEvent("NPCDamaged")         -- visual feedback
 makeRemoteEvent("NPCEliminated")      -- server → all: npcType, position
+makeRemoteEvent("NPCFireWeapon")      -- server → all: npcModel, muzzlePos, targetPos (visual flash + tracer)
 
 -- Kill feed
 makeRemoteEvent("KillFeed")           -- server → all: killer, victim, weapon

--- a/src/ServerScriptService/MatchManager.lua
+++ b/src/ServerScriptService/MatchManager.lua
@@ -58,11 +58,10 @@ end
 function MatchManager.setPhase(phase)
 	MatchManager.CurrentPhase = phase
 	PhaseChanged:FireAllClients(phase)
-	-- Phases without an active countdown should clear the timer label (#6).
-	-- PvE / PvPWarning push their own per-second TimerUpdate, the others don't.
-	if phase == GameConfig.PHASE.PVP
-		or phase == GameConfig.PHASE.MATCH_END
-		or phase == GameConfig.PHASE.LOBBY then
+	-- Phases without an active countdown clear the timer label.
+	-- PvE / PvPWarning / PvP all push their own per-second TimerUpdate now (#19),
+	-- so only MATCH_END / LOBBY need the explicit zero clear.
+	if phase == GameConfig.PHASE.MATCH_END or phase == GameConfig.PHASE.LOBBY then
 		TimerUpdate:FireAllClients(0)
 	end
 	print("[MatchManager] Phase:", phase)
@@ -233,6 +232,12 @@ function MatchManager.eliminatePlayer(player, killer)
 				player.Character.HumanoidRootPart.CFrame = specSpawn.CFrame + Vector3.new(0, 3, 0)
 			end
 		end
+		-- Reset HUD HP back to full so the HP bar in the spectator/lobby view
+		-- shows 100/100 instead of the 0/100 from when they died (#18). The
+		-- per-match playerData is left as Eliminated=true so they can't fight
+		-- back this match.
+		data.HP = data.MaxHP
+		events:WaitForChild("HealthUpdate"):FireClient(player, data.MaxHP, data.MaxHP)
 	end)
 
 	-- Check win condition
@@ -308,7 +313,9 @@ function MatchManager.resetToLobby()
 	MatchManager.PvPEnabled = false
 	playerData = {}
 
-	-- Teleport all players to lobby
+	-- Teleport all players to lobby + reset HUD HP back to full (#18) so the
+	-- HP bar doesn't keep showing whatever it was at when the match ended.
+	local healthUpdate = events:WaitForChild("HealthUpdate")
 	for _, player in ipairs(Players:GetPlayers()) do
 		player:LoadCharacter()
 		task.wait(0.5)
@@ -320,6 +327,7 @@ function MatchManager.resetToLobby()
 				player.Character.HumanoidRootPart.CFrame = lobbySpawn.CFrame + Vector3.new(0, 3, 0)
 			end
 		end
+		healthUpdate:FireClient(player, GameConfig.MAX_HP, GameConfig.MAX_HP)
 	end
 
 	Announcement:FireAllClients("WAITING FOR MATCH...")
@@ -420,7 +428,23 @@ function MatchManager.startMatch()
 	MatchManager.PvPEnabled = true
 	Announcement:FireAllClients("⚔ FINAL STRIKE - LAST ONE STANDING WINS ⚔")
 
-	-- PvP runs until someone wins (checkWinCondition handles it)
+	-- PvP has a 5-minute cap (#19). Whoever's alive when time runs out wins;
+	-- if everyone died, the match ends with NO SURVIVORS. checkWinCondition
+	-- can also end the match early once aliveCount drops to 1.
+	for t = GameConfig.PVP_DURATION, 1, -1 do
+		if not MatchManager.MatchRunning then return end
+		TimerUpdate:FireAllClients(t)
+		task.wait(1)
+	end
+
+	if MatchManager.MatchRunning then
+		-- Time ran out — pick first surviving player as winner
+		local winner = nil
+		for p, _ in pairs(MatchManager.AlivePlayers) do
+			if p.Parent then winner = p; break end
+		end
+		MatchManager.endMatch(winner)
+	end
 end
 
 -- ============ LOBBY TRIGGER ============

--- a/src/ServerScriptService/NPCSystem.lua
+++ b/src/ServerScriptService/NPCSystem.lua
@@ -5,9 +5,21 @@ local Players = game:GetService("Players")
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local RunService = game:GetService("RunService")
 local PathfindingService = game:GetService("PathfindingService")
+local ServerStorage = game:GetService("ServerStorage")
 
 local GameConfig = require(ReplicatedStorage:WaitForChild("GameConfig"))
+local WeaponMeshes = require(ServerStorage:WaitForChild("WeaponMeshes"))
 local events = ReplicatedStorage:WaitForChild("GameEvents")
+
+-- NPC weapon loadout by enemy type (#20). Picks an existing GameConfig weapon
+-- whose mesh fits the NPC's role (Patrol = pistol, Armored = SMG, Elite = rifle).
+-- The weapon is purely visual + drives muzzle flash position; damage still
+-- comes from GameConfig.ENEMIES[type].Damage in the AI loop.
+local NPC_WEAPON = {
+	Patrol  = "Viper Mk1",       -- pistol
+	Armored = "Stinger Mk2",     -- SMG
+	Elite   = "Phantom Ranger",  -- rifle
+}
 
 local NPCSystem = {}
 local activeNPCs = {}
@@ -142,6 +154,16 @@ local function createR15NPC(enemyType, position)
 
 	-- Per-type silhouette accessories (helmet, vest, hood, etc.)
 	dressNPC(model, enemyType)
+
+	-- Equip a visible weapon Tool so players can see what each NPC type carries (#20).
+	-- Weapon is purely visual: damage still comes from config.Damage in the AI loop.
+	local weaponName = NPC_WEAPON[enemyType]
+	if weaponName then
+		local tool = WeaponMeshes.build(weaponName)
+		if tool then
+			tool.Parent = model  -- Tool parented to character auto-equips and grips in RightHand
+		end
+	end
 
 	-- Position so feet land just above the floor; Humanoid HipHeight handles
 	-- the rest. The marker sits at y=1 (above ArenaFloor at y=0); pivot the
@@ -371,6 +393,18 @@ local function runNPCAI(npcModel)
 					if mm then
 						mm.damagePlayer(closestPlayer, npcModel:GetAttribute("Damage"))
 					end
+					-- Fire visual flash + tracer to all clients (#20). Origin = NPC's
+					-- weapon Muzzle attachment if present; falls back to Head position.
+					local muzzlePos = root.Position + Vector3.new(0, 1.5, 0)  -- chest-level fallback
+					local tool = npcModel:FindFirstChildOfClass("Tool")
+					local handle = tool and tool:FindFirstChild("Handle")
+					local muzzle = handle and handle:FindFirstChild("Muzzle")
+					if muzzle then muzzlePos = muzzle.WorldPosition end
+					local targetPos = closestPlayer.Character
+						and closestPlayer.Character:FindFirstChild("HumanoidRootPart")
+						and closestPlayer.Character.HumanoidRootPart.Position
+						or (root.Position + Vector3.new(0, 1.5, 0))
+					events.NPCFireWeapon:FireAllClients(npcModel, muzzlePos, targetPos)
 				end
 			else
 				-- Chase via PathfindingService so NPCs route around cover

--- a/src/ServerScriptService/NPCSystem.lua
+++ b/src/ServerScriptService/NPCSystem.lua
@@ -385,7 +385,22 @@ local function runNPCAI(npcModel)
 			if closestDist <= attackRange then
 				-- Attack
 				npcModel:SetAttribute("State", "Attack")
-				humanoid:MoveTo(root.Position)  -- stop
+				humanoid:MoveTo(root.Position)  -- stop walking
+
+				-- Face the player before firing (#22) — only Y-axis rotation so
+				-- the NPC stays upright. Done every attack-frame, not just on
+				-- shot, so the body smoothly tracks a moving target instead of
+				-- staring blankly while the muzzle flashes off-axis.
+				local targetCharPos = closestPlayer.Character
+					and closestPlayer.Character:FindFirstChild("HumanoidRootPart")
+					and closestPlayer.Character.HumanoidRootPart.Position
+				if targetCharPos then
+					local lookAt = Vector3.new(targetCharPos.X, root.Position.Y, targetCharPos.Z)
+					-- Skip if target is right on top of us (CFrame.lookAt would error)
+					if (lookAt - root.Position).Magnitude > 0.1 then
+						root.CFrame = CFrame.lookAt(root.Position, lookAt)
+					end
+				end
 
 				if tick() - lastAttack >= npcModel:GetAttribute("AttackRate") then
 					lastAttack = tick()

--- a/src/StarterPlayerScripts/CameraController.lua
+++ b/src/StarterPlayerScripts/CameraController.lua
@@ -50,17 +50,27 @@ end
 -- enforcing so right-click drag and click-to-move work normally (#14, #15).
 local releaseEnforceUntil = 0
 
+-- Crosshair visibility — only show when actually aiming in first-person.
+-- Hidden in lobby (no shooting context), spectator, and while a menu is open.
+local function setCrosshairVisible(visible)
+	local pg = player:FindFirstChild("PlayerGui")
+	local cross = pg and pg:FindFirstChild("FinalStrikeCrosshair")
+	if cross then cross.Enabled = visible end
+end
+
 local function applyCameraState()
 	if shouldLock() then
 		player.CameraMode = Enum.CameraMode.LockFirstPerson
 		UserInputService.MouseIconEnabled = false
 		releaseEnforceUntil = 0
+		setCrosshairVisible(true)
 	else
 		player.CameraMode = Enum.CameraMode.Classic
 		UserInputService.MouseIconEnabled = true
 		UserInputService.MouseBehavior = Enum.MouseBehavior.Default
 		-- Hold Default for ~1s so CameraScript's transition can't re-lock us
 		releaseEnforceUntil = tick() + 1.0
+		setCrosshairVisible(false)
 	end
 end
 

--- a/src/StarterPlayerScripts/HUDController.lua
+++ b/src/StarterPlayerScripts/HUDController.lua
@@ -264,6 +264,7 @@ local crosshairGui = Instance.new("ScreenGui")
 crosshairGui.Name = "FinalStrikeCrosshair"
 crosshairGui.ResetOnSpawn = false
 crosshairGui.IgnoreGuiInset = true
+crosshairGui.Enabled = false  -- hidden by default; CameraController shows it in arena
 crosshairGui.Parent = player.PlayerGui
 
 -- CEO-spec 4-segment open-center reticle: top/bottom/left/right white lines

--- a/src/StarterPlayerScripts/NPCWeaponEffectsClient.lua
+++ b/src/StarterPlayerScripts/NPCWeaponEffectsClient.lua
@@ -1,0 +1,62 @@
+-- NPCWeaponEffectsClient.lua (StarterPlayerScripts)
+-- Renders muzzle flash + bullet tracer when an NPC fires (#20). Server fires
+-- NPCFireWeapon RemoteEvent with (npcModel, muzzlePos, targetPos); each client
+-- spawns purely local FX so dozens of NPCs in a fight don't replicate Parts.
+
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local TweenService = game:GetService("TweenService")
+local Debris = game:GetService("Debris")
+
+local events = ReplicatedStorage:WaitForChild("GameEvents")
+
+local function spawnMuzzleFlash(pos)
+	local flash = Instance.new("Part")
+	flash.Size = Vector3.new(0.5, 0.5, 0.5)
+	flash.CFrame = CFrame.new(pos)
+	flash.Anchored = true
+	flash.CanCollide = false
+	flash.Material = Enum.Material.Neon
+	flash.Color = Color3.fromRGB(255, 220, 130)
+	flash.Shape = Enum.PartType.Ball
+	flash.Parent = workspace
+
+	local light = Instance.new("PointLight")
+	light.Color = Color3.fromRGB(255, 200, 110)
+	light.Brightness = 6
+	light.Range = 10
+	light.Parent = flash
+
+	TweenService:Create(flash, TweenInfo.new(0.08), {
+		Transparency = 1,
+		Size = Vector3.new(0.05, 0.05, 0.05),
+	}):Play()
+	TweenService:Create(light, TweenInfo.new(0.08), { Brightness = 0 }):Play()
+	Debris:AddItem(flash, 0.15)
+end
+
+local function spawnTracer(fromPos, toPos)
+	-- Thin cylindrical beam from muzzle to target, fades out fast
+	local diff = toPos - fromPos
+	local length = diff.Magnitude
+	if length < 0.5 then return end
+
+	local tracer = Instance.new("Part")
+	tracer.Size = Vector3.new(0.08, 0.08, length)
+	tracer.CFrame = CFrame.lookAt(fromPos + diff * 0.5, toPos)
+	tracer.Anchored = true
+	tracer.CanCollide = false
+	tracer.Material = Enum.Material.Neon
+	tracer.Color = Color3.fromRGB(255, 230, 140)
+	tracer.Transparency = 0.3
+	tracer.Parent = workspace
+
+	TweenService:Create(tracer, TweenInfo.new(0.12), { Transparency = 1 }):Play()
+	Debris:AddItem(tracer, 0.2)
+end
+
+events:WaitForChild("NPCFireWeapon").OnClientEvent:Connect(function(npcModel, muzzlePos, targetPos)
+	-- npcModel param accepted for future per-NPC effects (sound by enemyType etc.)
+	if not muzzlePos or not targetPos then return end
+	spawnMuzzleFlash(muzzlePos)
+	spawnTracer(muzzlePos, targetPos)
+end)


### PR DESCRIPTION
## Summary
Three combat-loop fixes from playtest feedback.

Closes #18, closes #19, closes #20.

## #18 — HP bar stuck at 0/100 after death
\`MatchManager.eliminatePlayer\` now resets \`data.HP=MaxHP\` + fires HealthUpdate after the spectator teleport. \`resetToLobby\` also fires HealthUpdate(MAX,MAX) for every player so the bar returns to full when the match ends.

## #19 — PvP phase had no timer
Added \`GameConfig.PVP_DURATION = 300\` (5 min cap). \`startMatch\` runs a per-second TimerUpdate loop through PvP. If the timer expires and the match is still running, \`endMatch\` picks the first surviving player as winner (or NO SURVIVORS if no one's alive). \`checkWinCondition\` still ends early when alive count drops to 1.

## #20 — NPC weapons + fire visuals
- **NPCSystem**: \`NPC_WEAPON\` map (Patrol→Viper Mk1, Armored→Stinger Mk2, Elite→Phantom Ranger). \`createR15NPC\` builds the Tool via \`WeaponMeshes.build\` and parents it to the NPC model — engine's grip system holds it in RightHand.
- AI loop fires \`NPCFireWeapon\` RemoteEvent on every shot with \`(npcModel, muzzlePos, targetPos)\`. Muzzle position comes from the Tool's Handle.Muzzle attachment, else chest-level fallback.
- **NPCWeaponEffectsClient.lua** (new) renders a yellow muzzle flash sphere + thin tracer cylinder on each fire. Client-only so dozens of NPC shots don't replicate Parts.

## Test plan
- [x] **#18**: HP reset logic verified (data.HP=MaxHP + HealthUpdate fires after teleport; resetToLobby loops over all players)
- [x] **#19**: \`PVP_DURATION = 300\` confirmed; PvP loop runs per-second TimerUpdate
- [x] **#20**: 9/9 NPCs spawned with Tools (4 Patrol pistols, 3 Armored SMGs, 2 Elite rifles); standing next to Patrol triggered NPCFireWeapon event; muzzle flash rendered visibly (screenshot in PR comment)
- [ ] End-to-end: play one full match, get killed → confirm HP shows 100/100 in spectator + lobby; survive PvE into PvP → confirm timer counts 5:00 → 0:00; engage NPC at distance → confirm tracer beam visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)