### PR TITLE
feat(sprint-8b): 200 HP rebalance + 30-weapon DPS retune + Sniper headshot

### DIFF
--- a/receipts/sprint-8b-200hp-rebalance.md
+++ b/receipts/sprint-8b-200hp-rebalance.md
@@ -1,0 +1,129 @@
+# Sprint 8b Receipt — 200 HP rebalance + 30-weapon DPS retune + Sniper headshot
+
+Date: 2026-05-03
+Driving feedback: CEO 200 HP 提案 + decision (b) 30-weapon DPS gap convergence + D1 全 Sniper 1-shot 爆頭
+Source proposals: `proposals/sprint-8-200hp-balance.md` (PR #23) + `proposals/30-weapon-dps-retune.md` (PR #25)
+
+## Status: ✅ IMPLEMENTED（待 Studio playtest verification）
+
+## Work Items
+
+### Player blood (workloads/03)
+- [x] `GameConfig.MAX_HP` 100 → **200**
+- [x] `GameConfig.HEADSHOT_MULTIPLIER = 2.0` 新增（Sniper Type only）
+- [x] `MatchManager.initPlayerData` 起始 200 HP（透過 GameConfig.MAX_HP，無硬編碼）
+- [x] `healPlayer` 邏輯不變，由 LootSystem / NPCSystem 傳入對應 4 階 amount
+- [x] `HUDController` line 52 初始 hpText 從硬編碼 "100 / 100" 改為動態 `GameConfig.MAX_HP`
+
+### Weapon system (workloads/04)
+- [x] `GameConfig.RARITY` DPS 倍率：1.0/1.25/1.55/1.95/2.40/3.00 → **1.0/1.15/1.30/1.50/1.70/1.90**
+- [x] **30 武器 Damage 重平衡** per `proposals/30-weapon-dps-retune.md` §9 template
+  - Common (5): Viper Mk1 25→30, Viper SD 22→24, Fang Scout 40 (no change), Thunder Stub 12→14, Thunder Cut 11 (no change)
+  - Uncommon (5): Stinger Mk2 16→11, Stinger Tac 18→12, Phantom Ranger 35→19, Wraith Scout 70→**120**, Stinger Burst 14→9
+  - Rare (5): Reaver-X 42→20, Phantom Night 38→17, Thunder Guard 14→12, Wraith Hunter 110→**172**, Thunder Triple 15→11
+  - Epic (6): Stinger Storm 22→12, Phantom Apex 50→21, Wraith Frost 140→**190**, Phantom Whisper 55→25, Thunder Royal 18→13, Viper Left 70→62
+  - Legendary (5): Viper Aurum 60→51, Phantom Finale 60→24, Wraith Apex 170→**206**, Thunder Crown 22→14, Hailstorm 18 (no change — option B)
+  - Demon (4): Fang Demon 120→76, Phantom Hellfire 75→27, Wraith Abyss 210→**220**, Thunder Bloodmoon 28→14
+- [x] **Sniper headshot D1**：`MatchManager.lua` FireWeapon handler 加 `config.Type == "Sniper" and hitPart.Name == "Head"` 分支套用 HEADSHOT_MULTIPLIER（×2.0）
+- [x] 其他 Type（Pistol/SMG/Rifle/Shotgun/Knife/Minigun）爆頭 = 一般 Damage（嚴格 scope D1）
+- [x] NPC 爆頭也適用同一機制（NPC 也有 Head part）
+
+### NPC system (workloads/05)
+- [x] `ENEMIES.Patrol`: HP 60→**120** / Damage 10→**18** / Speed 12 (no change)
+- [x] `ENEMIES.Armored`: HP 150→**300** / Damage 15→**28** / Speed 8
+- [x] `ENEMIES.Elite`: HP 250→**500** / Damage 25→**40** / Speed 14
+- [x] `LootTable` 更新對應 4 階 medkit type（移除舊的單一 Medkit）：
+  - Patrol: `{ Ammo=0.50, MedkitSmall=0.25, Coin=0.20 }`
+  - Armored: `{ Ammo=0.50, Medkit=0.35, Coin=0.35 }`
+  - Elite: `{ Ammo=0.40, MedkitLarge=0.50, MedkitFull=0.05, Coin=0.50 }`
+- [x] `dropLoot` 顏色 + Touched handler 對應 4 階 medkit
+
+### Loot system (workloads/06)
+- [x] `GameConfig.LOOT` 加 4 階：MedkitSmall=50 / Medkit=100 / MedkitLarge=150 / MedkitFull=200
+- [x] `createPickup` 顏色：淺綠 (120,255,150) → 標準綠 (50,255,100) → 深綠 (20,200,80) → 米白 (255,255,200)
+- [x] Touched handler 4 種 medkit type 共用 GameConfig.LOOT[lootType].Heal lookup
+
+### HUD (workloads/07)
+- [x] HP 條使用比例計算（hp/maxHP），200 HP 自動適配
+- [x] 顏色閾值維持 >60% 綠 / >30% 黃 / ≤30% 紅
+- [x] 初始文字從硬編碼 "100 / 100" 改為 GameConfig.MAX_HP 動態
+
+## Test Evidence (post-implementation, pre-playtest)
+
+### 程式碼變更統計
+- `src/ReplicatedStorage/GameConfig.lua`: ~50 lines（30 武器 + RARITY + ENEMIES + LOOT）
+- `src/ServerScriptService/MatchManager.lua`: ~20 lines（FireWeapon Sniper headshot 分支）
+- `src/ServerScriptService/NPCSystem.lua`: ~15 lines（dropLoot 4 階 medkit）
+- `src/ServerScriptService/LootSystem.lua`: ~15 lines（createPickup 4 階 medkit）
+- `src/StarterPlayerScripts/HUDController.lua`: ~3 lines（GameConfig require + dynamic 200 HP text）
+- 5 個 workload contracts status 標 RESOLVED + 本 receipt
+
+### 數值驗證（DPS 公式套用）
+所有 30 武器 Damage 落在新公式 ±5% 範圍：
+- Common Pistol Viper Mk1: 30 dmg / 0.40 = **75 DPS** ✓ baseline
+- Demon Knife Fang Demon: 76 dmg / 0.50 = **152 DPS** = 80 × 1.90 ✓
+- Sniper Wraith Abyss: 220 dmg / 1.05 = **209.5 DPS** ≈ 110 × 1.90 ✓
+- Shotgun Thunder Bloodmoon: 14×8/0.60 = **186.7 DPS** = 99 × 1.89 ✓ (nearly perfect)
+
+### Headshot 機制驗證（理論）
+所有 Sniper post-(b) headshot 對 200 HP 玩家：
+- Wraith Scout: 120 × 2.0 = 240 → **1-shot ✓**
+- Wraith Hunter: 172 × 2.0 = 344 → **1-shot ✓**
+- Wraith Frost: 190 × 2.0 = 380 → **1-shot ✓**
+- Wraith Apex: 206 × 2.0 = 412 → **1-shot ✓**
+- Wraith Abyss: 220 × 2.0 = 440 → **1-shot ✓**
+
+D1 達成：5 把 Sniper 全部 post-(b) 爆頭 1-shot，付費差距由其他維度體現（body TTK / Range / Pierce）。
+
+## Known Issues / Pending Verification
+
+### 🟡 待 Studio playtest 確認
+- [ ] 200 HP 起始實際 spawn / HUD 顯示
+- [ ] Patrol NPC 站樁攻擊 → 玩家 200 HP 真實掉血速度（理論 11.1s 對 18 dmg/1.0s）
+- [ ] Phantom Ranger (19 dmg) 對 Patrol (120 HP) 殺敵時間（理論 7 發 / 0.90s）
+- [ ] Wraith Scout 爆頭 R15 NPC.Head 觸發 240 dmg（從 console_output 觀察 NPCDamaged 數字）
+- [ ] 4 階 medkit pickup 顏色目視差異
+- [ ] MedkitFull 5% drop on Elite 實測抽取（若不出現，可能要 console 顯式測）
+- [ ] 30 武器全部能正常射擊（loop 跑商店買 30 把 + 切 primary 測）
+
+### 🟡 邊界情況待測
+- [ ] NPC 戴帽子 (Patrol cap / Armored helmet / Elite hood) 命中時 hitPart.Name 確認不是 "Head"（不算爆頭，吃到頭盔擋下）
+- [ ] Wraith Abyss `Pierce=true` 多人命中：每根 raycast 各自判 headshot
+- [ ] Phantom Hellfire `Burn=true` DOT 機制是否仍生效（未量化進 Damage，但 Burn 邏輯應該獨立）
+
+### 🟡 需要後續觀察的設計風險
+- [ ] **Demon 武器 -37%~-64% Damage nerf** 玩家手感 — CEO 已接受，但實戰可能感受到「Demon 變弱」，需 1-2 週玩家數據
+- [ ] **Sniper TTK 結構性偏短**（Wraith Scout 2-body-shot 0.95s, Wraith Hunter 1.20s）— Sniper 可能成為 PvP 主導武器
+- [ ] **新手 Common Viper Mk1 vs Demon Wraith Abyss** TTK 仍 1:N 但已從 1:無限收斂；玩家觀感待測
+- [ ] **MedkitFull 5%** 機率太低可能讓玩家覺得「永遠抽不到」— 觀察玩家數據再調
+
+## Lessons Learned
+
+- **大批量數值改動分多個 commit 跨多個檔案易踩坑** — 用獨立 retune doc (proposals/30-weapon-dps-retune.md) 列 30 武器逐一 Damage + DPS 驗證，commit 時對照 doc 一行一行核對才不會漏
+- **Sniper Type-based 機制比寫死武器名乾淨太多** — 用 `config.Type == "Sniper"` 一句涵蓋 5 把 Wraith 系列；如果硬編碼武器名，每次商店加新 Sniper 都得改 server
+- **HUD 初始文字也要從 GameConfig 讀** — line 52 硬編碼 "100 / 100" 是 Sprint 1 留下的；玩家進大廳到 initPlayerData 觸發 HealthUpdate 之間有 ~1 frame 顯示舊文字
+- **DPS 公式收斂的副作用是 Demon nerf 比 Common buff 大** — Common Viper Mk1 +20% / Demon Phantom Hellfire -64%。CEO 須事前明確接受才不會在 Sprint 8b 後被質疑
+- **first-shot-immediate vs shots×FireRate** — Roblox client 射擊 timing 是 fire 然後 task.delay(FireRate)，所以 N 發殺敵 TTK = (N-1) × FireRate，比 shots × FireRate 快 1 個 FireRate。balance doc 一定要用對的 timing model 否則 CEO sign-off 失準（PR #25 review 抓到的 blocker）
+
+## Artifacts
+
+```
+src/ReplicatedStorage/GameConfig.lua          (200 HP, RARITY, 30 weapons, ENEMIES, LOOT)
+src/ServerScriptService/MatchManager.lua      (Sniper headshot branch in FireWeapon handler)
+src/ServerScriptService/NPCSystem.lua         (4-tier medkit colors + Touched handler)
+src/ServerScriptService/LootSystem.lua        (4-tier medkit colors + Touched handler)
+src/StarterPlayerScripts/HUDController.lua    (require GameConfig + dynamic init text)
+workloads/03-player-health.yaml               (status → ✅ DONE Sprint 8b)
+workloads/04-weapon-system.yaml               (status → ✅ DONE Sprint 8b)
+workloads/05-npc-system.yaml                  (status → ✅ DONE Sprint 8b)
+workloads/06-loot-system.yaml                 (status → ✅ DONE Sprint 8b)
+receipts/sprint-8b-200hp-rebalance.md         (本 receipt)
+```
+
+## Next: Sprint 9 候選
+
+- 護甲片系統（workloads/11-armor-system.yaml）— Q4 拍板做的話
+- Channel 式補血（按 H 使用 1 秒、可被打斷）— Q3 拍板做的話
+- 全武器 headshot 1.5x 評估（D1 之外擴展）— 需 playtest 後再定
+- Demon 武器商店價格是否調降（與本 sprint 的 nerf 對齊玩家感受）
+- 古代長火槍 — 4 把新武器中唯一未存在於 main，含獨特 reload mechanic

--- a/src/ReplicatedStorage/GameConfig.lua
+++ b/src/ReplicatedStorage/GameConfig.lua
@@ -12,9 +12,13 @@ GameConfig.PVP_DURATION = 300       -- seconds (5 min PvP cap; ends with current
 GameConfig.LOBBY_COUNTDOWN = 10     -- seconds before match starts
 GameConfig.SPAWN_PROTECTION = 3     -- seconds of NPC-damage immunity after teleport to arena
 
--- Player settings
-GameConfig.MAX_HP = 100
-GameConfig.MEDKIT_HEAL = 50
+-- Player settings (Sprint 8b: 200 HP rebalance)
+GameConfig.MAX_HP = 200
+GameConfig.MEDKIT_HEAL = 100  -- legacy fallback; new code reads GameConfig.LOOT[tier].Heal directly
+
+-- Headshot multiplier — Sprint 8b only Sniper Type applies (D1 decision)
+-- See proposals/sprint-8-200hp-balance.md §3.5 for full rationale.
+GameConfig.HEADSHOT_MULTIPLIER = 2.0
 
 -- Match phases
 GameConfig.PHASE = {
@@ -26,60 +30,65 @@ GameConfig.PHASE = {
 }
 
 -- Rarity tiers (UI color + DPS scaling vs Common baseline)
+-- Sprint 8b (b) decision: gap converged from 3.0x → 1.9x to reduce P2W feel.
+-- See proposals/30-weapon-dps-retune.md.
 GameConfig.RARITY = {
 	Common    = { Order = 1, DPS = 1.00, Color = Color3.fromRGB(200, 200, 200) },
-	Uncommon  = { Order = 2, DPS = 1.25, Color = Color3.fromRGB( 80, 220, 100) },
-	Rare      = { Order = 3, DPS = 1.55, Color = Color3.fromRGB( 80, 160, 255) },
-	Epic      = { Order = 4, DPS = 1.95, Color = Color3.fromRGB(180,  90, 240) },
-	Legendary = { Order = 5, DPS = 2.40, Color = Color3.fromRGB(255, 200,  60) },
-	Demon     = { Order = 6, DPS = 3.00, Color = Color3.fromRGB(220,  40,  40) },
+	Uncommon  = { Order = 2, DPS = 1.15, Color = Color3.fromRGB( 80, 220, 100) },  -- was 1.25
+	Rare      = { Order = 3, DPS = 1.30, Color = Color3.fromRGB( 80, 160, 255) },  -- was 1.55
+	Epic      = { Order = 4, DPS = 1.50, Color = Color3.fromRGB(180,  90, 240) },  -- was 1.95
+	Legendary = { Order = 5, DPS = 1.70, Color = Color3.fromRGB(255, 200,  60) },  -- was 2.40
+	Demon     = { Order = 6, DPS = 1.90, Color = Color3.fromRGB(220,  40,  40) },  -- was 3.00
 }
 
 -- Weapon definitions (fictional names only — no real-world brands)
--- Balance: Damage tuned so each weapon's DPS matches its rarity's DPS multiplier vs the
--- Common baseline (Viper Mk1 = 62.5 DPS pistol, Thunder Stub = 90 DPS shotgun, etc.)
+-- Balance: Sprint 8b (b) retune — Damage tuned so each weapon's DPS matches the
+-- new rarity multiplier (1.0 / 1.15 / 1.30 / 1.50 / 1.70 / 1.90) over Common baseline.
+-- Type baselines: Pistol 75 / SMG 110 / Rifle 110 / Shotgun 99 / Sniper 110 / Knife 80.
+-- Hailstorm Minigun: option B (Damage 18 unchanged, SpinUp is the trade-off).
+-- See proposals/30-weapon-dps-retune.md for full table + per-weapon TTK.
 GameConfig.WEAPONS = {
-	-- ===== Common (5) =====
-	["Viper Mk1"]      = { Type="Pistol",  Rarity="Common",    Price=  300, Damage= 25, FireRate=0.40, MagSize=12, ReloadTime=1.5, Range=200, Spread=0.020, Auto=false },
-	["Viper SD"]       = { Type="Pistol",  Rarity="Common",    Price=  350, Damage= 22, FireRate=0.32, MagSize=15, ReloadTime=1.6, Range=180, Spread=0.022, Auto=false },
-	["Fang Scout"]     = { Type="Knife",   Rarity="Common",    Price=  450, Damage= 40, AttackRate=0.50, Range=8 },
-	["Thunder Stub"]   = { Type="Shotgun", Rarity="Common",    Price=  550, Damage= 12, Pellets=6, FireRate=0.85, MagSize=4, ReloadTime=2.8, Range=40, Spread=0.12, Auto=false },
-	["Thunder Cut"]    = { Type="Shotgun", Rarity="Common",    Price=  650, Damage= 11, Pellets=8, FireRate=0.90, MagSize=5, ReloadTime=3.0, Range=45, Spread=0.11, Auto=false },
+	-- ===== Common (5) — 1.00x DPS =====
+	["Viper Mk1"]      = { Type="Pistol",  Rarity="Common",    Price=  300, Damage= 30, FireRate=0.40, MagSize=12, ReloadTime=1.5, Range=200, Spread=0.020, Auto=false },  -- was 25
+	["Viper SD"]       = { Type="Pistol",  Rarity="Common",    Price=  350, Damage= 24, FireRate=0.32, MagSize=15, ReloadTime=1.6, Range=180, Spread=0.022, Auto=false },  -- was 22
+	["Fang Scout"]     = { Type="Knife",   Rarity="Common",    Price=  450, Damage= 40, AttackRate=0.50, Range=8 },                                                          -- unchanged
+	["Thunder Stub"]   = { Type="Shotgun", Rarity="Common",    Price=  550, Damage= 14, Pellets=6, FireRate=0.85, MagSize=4, ReloadTime=2.8, Range=40, Spread=0.12, Auto=false },  -- was 12
+	["Thunder Cut"]    = { Type="Shotgun", Rarity="Common",    Price=  650, Damage= 11, Pellets=8, FireRate=0.90, MagSize=5, ReloadTime=3.0, Range=45, Spread=0.11, Auto=false },  -- unchanged
 
-	-- ===== Uncommon (5) — 1.25x DPS =====
-	["Stinger Mk2"]    = { Type="SMG",     Rarity="Uncommon",  Price= 1200, Damage= 16, FireRate=0.085, MagSize=30, ReloadTime=2.0, Range=150, Spread=0.040, Auto=true },
-	["Stinger Tac"]    = { Type="SMG",     Rarity="Uncommon",  Price= 1350, Damage= 18, FireRate=0.095, MagSize=28, ReloadTime=2.0, Range=160, Spread=0.038, Auto=true },
-	["Phantom Ranger"] = { Type="Rifle",   Rarity="Uncommon",  Price= 1500, Damage= 35, FireRate=0.15,  MagSize=25, ReloadTime=2.5, Range=300, Spread=0.018, Auto=true },
-	["Wraith Scout"]   = { Type="Sniper",  Rarity="Uncommon",  Price= 1650, Damage= 70, FireRate=0.95,  MagSize=8,  ReloadTime=3.0, Range=400, Spread=0.008, Auto=false },
-	["Stinger Burst"]  = { Type="SMG",     Rarity="Uncommon",  Price= 1800, Damage= 14, FireRate=0.07,  MagSize=32, ReloadTime=2.0, Range=140, Spread=0.045, Auto=true },
+	-- ===== Uncommon (5) — 1.15x DPS =====
+	["Stinger Mk2"]    = { Type="SMG",     Rarity="Uncommon",  Price= 1200, Damage= 11, FireRate=0.085, MagSize=30, ReloadTime=2.0, Range=150, Spread=0.040, Auto=true },  -- was 16
+	["Stinger Tac"]    = { Type="SMG",     Rarity="Uncommon",  Price= 1350, Damage= 12, FireRate=0.095, MagSize=28, ReloadTime=2.0, Range=160, Spread=0.038, Auto=true },  -- was 18
+	["Phantom Ranger"] = { Type="Rifle",   Rarity="Uncommon",  Price= 1500, Damage= 19, FireRate=0.15,  MagSize=25, ReloadTime=2.5, Range=300, Spread=0.018, Auto=true },  -- was 35
+	["Wraith Scout"]   = { Type="Sniper",  Rarity="Uncommon",  Price= 1650, Damage=120, FireRate=0.95,  MagSize=8,  ReloadTime=3.0, Range=400, Spread=0.008, Auto=false }, -- was 70
+	["Stinger Burst"]  = { Type="SMG",     Rarity="Uncommon",  Price= 1800, Damage=  9, FireRate=0.07,  MagSize=32, ReloadTime=2.0, Range=140, Spread=0.045, Auto=true },  -- was 14
 
-	-- ===== Rare (5) — 1.55x DPS =====
-	["Reaver-X"]       = { Type="Rifle",   Rarity="Rare",      Price= 3000, Damage= 42, FireRate=0.14,  MagSize=30, ReloadTime=2.4, Range=320, Spread=0.020, Auto=true },
-	["Phantom Night"]  = { Type="Rifle",   Rarity="Rare",      Price= 3300, Damage= 38, FireRate=0.12,  MagSize=30, ReloadTime=2.3, Range=320, Spread=0.014, Auto=true },
-	["Thunder Guard"]  = { Type="Shotgun", Rarity="Rare",      Price= 3600, Damage= 14, Pellets=8, FireRate=0.75, MagSize=6, ReloadTime=2.7, Range=55, Spread=0.10, Auto=false },
-	["Wraith Hunter"]  = { Type="Sniper",  Rarity="Rare",      Price= 4000, Damage=110, FireRate=1.20,  MagSize=6,  ReloadTime=3.2, Range=480, Spread=0.006, Auto=false },
-	["Thunder Triple"] = { Type="Shotgun", Rarity="Rare",      Price= 4500, Damage= 15, Pellets=9, FireRate=0.80, MagSize=3, ReloadTime=3.5, Range=50, Spread=0.13, Auto=false },
+	-- ===== Rare (5) — 1.30x DPS =====
+	["Reaver-X"]       = { Type="Rifle",   Rarity="Rare",      Price= 3000, Damage= 20, FireRate=0.14,  MagSize=30, ReloadTime=2.4, Range=320, Spread=0.020, Auto=true },  -- was 42
+	["Phantom Night"]  = { Type="Rifle",   Rarity="Rare",      Price= 3300, Damage= 17, FireRate=0.12,  MagSize=30, ReloadTime=2.3, Range=320, Spread=0.014, Auto=true },  -- was 38
+	["Thunder Guard"]  = { Type="Shotgun", Rarity="Rare",      Price= 3600, Damage= 12, Pellets=8, FireRate=0.75, MagSize=6, ReloadTime=2.7, Range=55, Spread=0.10, Auto=false },  -- was 14
+	["Wraith Hunter"]  = { Type="Sniper",  Rarity="Rare",      Price= 4000, Damage=172, FireRate=1.20,  MagSize=6,  ReloadTime=3.2, Range=480, Spread=0.006, Auto=false }, -- was 110
+	["Thunder Triple"] = { Type="Shotgun", Rarity="Rare",      Price= 4500, Damage= 11, Pellets=9, FireRate=0.80, MagSize=3, ReloadTime=3.5, Range=50, Spread=0.13, Auto=false },  -- was 15
 
-	-- ===== Epic (6) — 1.95x DPS =====
-	["Stinger Storm"]  = { Type="SMG",     Rarity="Epic",      Price= 7500, Damage= 22, FireRate=0.075, MagSize=35, ReloadTime=1.9, Range=170, Spread=0.035, Auto=true },
-	["Phantom Apex"]   = { Type="Rifle",   Rarity="Epic",      Price= 8000, Damage= 50, FireRate=0.13,  MagSize=30, ReloadTime=2.2, Range=340, Spread=0.013, Auto=true },
-	["Wraith Frost"]   = { Type="Sniper",  Rarity="Epic",      Price= 8500, Damage=140, FireRate=1.15,  MagSize=6,  ReloadTime=3.0, Range=520, Spread=0.005, Auto=false },
-	["Phantom Whisper"]= { Type="Rifle",   Rarity="Epic",      Price= 9000, Damage= 55, FireRate=0.15,  MagSize=24, ReloadTime=2.4, Range=360, Spread=0.011, Auto=true, Silent=true },
-	["Thunder Royal"]  = { Type="Shotgun", Rarity="Epic",      Price= 9800, Damage= 18, Pellets=8, FireRate=0.70, MagSize=6, ReloadTime=2.6, Range=60, Spread=0.09, Auto=false },
-	["Viper Left"]     = { Type="Pistol",  Rarity="Epic",      Price= 9800, Damage= 70, FireRate=0.55,  MagSize=6,  ReloadTime=1.8, Range=240, Spread=0.018, Auto=false },
+	-- ===== Epic (6) — 1.50x DPS =====
+	["Stinger Storm"]  = { Type="SMG",     Rarity="Epic",      Price= 7500, Damage= 12, FireRate=0.075, MagSize=35, ReloadTime=1.9, Range=170, Spread=0.035, Auto=true },  -- was 22
+	["Phantom Apex"]   = { Type="Rifle",   Rarity="Epic",      Price= 8000, Damage= 21, FireRate=0.13,  MagSize=30, ReloadTime=2.2, Range=340, Spread=0.013, Auto=true },  -- was 50
+	["Wraith Frost"]   = { Type="Sniper",  Rarity="Epic",      Price= 8500, Damage=190, FireRate=1.15,  MagSize=6,  ReloadTime=3.0, Range=520, Spread=0.005, Auto=false }, -- was 140
+	["Phantom Whisper"]= { Type="Rifle",   Rarity="Epic",      Price= 9000, Damage= 25, FireRate=0.15,  MagSize=24, ReloadTime=2.4, Range=360, Spread=0.011, Auto=true, Silent=true },  -- was 55 (Silent unchanged)
+	["Thunder Royal"]  = { Type="Shotgun", Rarity="Epic",      Price= 9800, Damage= 13, Pellets=8, FireRate=0.70, MagSize=6, ReloadTime=2.6, Range=60, Spread=0.09, Auto=false },  -- was 18
+	["Viper Left"]     = { Type="Pistol",  Rarity="Epic",      Price= 9800, Damage= 62, FireRate=0.55,  MagSize=6,  ReloadTime=1.8, Range=240, Spread=0.018, Auto=false },  -- was 70
 
-	-- ===== Legendary (5) — 2.40x DPS =====
-	["Viper Aurum"]    = { Type="Pistol",  Rarity="Legendary", Price=16000, Damage= 60, FireRate=0.40,  MagSize=12, ReloadTime=1.4, Range=260, Spread=0.015, Auto=false },
-	["Phantom Finale"] = { Type="Rifle",   Rarity="Legendary", Price=18000, Damage= 60, FireRate=0.13,  MagSize=30, ReloadTime=2.1, Range=360, Spread=0.012, Auto=true },
-	["Wraith Apex"]    = { Type="Sniper",  Rarity="Legendary", Price=20000, Damage=170, FireRate=1.10,  MagSize=6,  ReloadTime=2.9, Range=560, Spread=0.004, Auto=false },
-	["Thunder Crown"]  = { Type="Shotgun", Rarity="Legendary", Price=22000, Damage= 22, Pellets=8, FireRate=0.65, MagSize=6, ReloadTime=2.5, Range=65, Spread=0.085, Auto=false },
-	["Hailstorm"]      = { Type="Minigun", Rarity="Legendary", Price=25000, Damage= 18, FireRate=0.05,  MagSize=120,ReloadTime=4.5, Range=220, Spread=0.055, Auto=true, SpinUp=0.5 },
+	-- ===== Legendary (5) — 1.70x DPS =====
+	["Viper Aurum"]    = { Type="Pistol",  Rarity="Legendary", Price=16000, Damage= 51, FireRate=0.40,  MagSize=12, ReloadTime=1.4, Range=260, Spread=0.015, Auto=false },  -- was 60
+	["Phantom Finale"] = { Type="Rifle",   Rarity="Legendary", Price=18000, Damage= 24, FireRate=0.13,  MagSize=30, ReloadTime=2.1, Range=360, Spread=0.012, Auto=true },  -- was 60
+	["Wraith Apex"]    = { Type="Sniper",  Rarity="Legendary", Price=20000, Damage=206, FireRate=1.10,  MagSize=6,  ReloadTime=2.9, Range=560, Spread=0.004, Auto=false }, -- was 170
+	["Thunder Crown"]  = { Type="Shotgun", Rarity="Legendary", Price=22000, Damage= 14, Pellets=8, FireRate=0.65, MagSize=6, ReloadTime=2.5, Range=65, Spread=0.085, Auto=false },  -- was 22
+	["Hailstorm"]      = { Type="Minigun", Rarity="Legendary", Price=25000, Damage= 18, FireRate=0.05,  MagSize=120,ReloadTime=4.5, Range=220, Spread=0.055, Auto=true, SpinUp=0.5 },  -- unchanged (option B)
 
-	-- ===== Demon (4) — 3.00x DPS =====
-	["Fang Demon"]     = { Type="Knife",   Rarity="Demon",     Price=35000, Damage=120, AttackRate=0.50, Range=10 },
-	["Phantom Hellfire"]= {Type="Rifle",   Rarity="Demon",     Price=42000, Damage= 75, FireRate=0.13,  MagSize=30, ReloadTime=2.0, Range=380, Spread=0.012, Auto=true, Burn=true },
-	["Wraith Abyss"]   = { Type="Sniper",  Rarity="Demon",     Price=48000, Damage=210, FireRate=1.05,  MagSize=5,  ReloadTime=2.8, Range=600, Spread=0.003, Auto=false, Pierce=true },
-	["Thunder Bloodmoon"]={Type="Shotgun", Rarity="Demon",     Price=55000, Damage= 28, Pellets=8, FireRate=0.60, MagSize=6, ReloadTime=2.3, Range=70, Spread=0.080, Auto=false },
+	-- ===== Demon (4) — 1.90x DPS =====
+	["Fang Demon"]     = { Type="Knife",   Rarity="Demon",     Price=35000, Damage= 76, AttackRate=0.50, Range=10 },  -- was 120
+	["Phantom Hellfire"]= {Type="Rifle",   Rarity="Demon",     Price=42000, Damage= 27, FireRate=0.13,  MagSize=30, ReloadTime=2.0, Range=380, Spread=0.012, Auto=true, Burn=true },  -- was 75 (Burn unchanged)
+	["Wraith Abyss"]   = { Type="Sniper",  Rarity="Demon",     Price=48000, Damage=220, FireRate=1.05,  MagSize=5,  ReloadTime=2.8, Range=600, Spread=0.003, Auto=false, Pierce=true },  -- was 210 (Pierce unchanged)
+	["Thunder Bloodmoon"]={Type="Shotgun", Rarity="Demon",     Price=55000, Damage= 14, Pellets=8, FireRate=0.60, MagSize=6, ReloadTime=2.3, Range=70, Spread=0.080, Auto=false },  -- was 28
 }
 
 -- Default starter weapons — every player owns these from the start, no purchase needed
@@ -122,45 +131,50 @@ GameConfig.DAILY_QUESTS = {
 	{ Id = "pickup5loot",    Name = "拾取 5 個戰利品",   EventType = "LootPickup",    Target = 5,   Reward = 250 },
 }
 
--- NPC enemy types
+-- NPC enemy types — Sprint 8b: HP/Damage ×2 to keep PvE pressure under 200 HP players.
+-- LootTable expanded into 4-tier medkit ladder matching player's new heal options.
 GameConfig.ENEMIES = {
 	Patrol = {
-		HP = 60,
-		Damage = 10,
+		HP = 120,    -- was 60
+		Damage = 18, -- was 10
 		Speed = 12,
 		DetectRange = 40,
 		AttackRange = 6,
 		AttackRate = 1.0,
-		LootTable = { Ammo = 0.7, Coin = 0.3 },
+		LootTable = { Ammo = 0.50, MedkitSmall = 0.25, Coin = 0.20 },
 		Color = Color3.fromRGB(120, 120, 120),
 	},
 	Armored = {
-		HP = 150,
-		Damage = 15,
+		HP = 300,    -- was 150
+		Damage = 28, -- was 15
 		Speed = 8,
 		DetectRange = 35,
 		AttackRange = 7,
 		AttackRate = 1.5,
-		LootTable = { Ammo = 0.5, Coin = 0.3, Medkit = 0.2 },
+		LootTable = { Ammo = 0.50, Medkit = 0.35, Coin = 0.35 },
 		Color = Color3.fromRGB(80, 80, 100),
 	},
 	Elite = {
-		HP = 250,
-		Damage = 25,
+		HP = 500,    -- was 250
+		Damage = 40, -- was 25
 		Speed = 14,
 		DetectRange = 50,
 		AttackRange = 8,
 		AttackRate = 0.8,
-		LootTable = { Ammo = 0.3, Coin = 0.4, Medkit = 0.3 },
+		LootTable = { Ammo = 0.40, MedkitLarge = 0.50, MedkitFull = 0.05, Coin = 0.50 },
 		Color = Color3.fromRGB(180, 40, 40),
 	},
 }
 
--- Loot pickup values (Weapon dropped removed — weapons are shop-only now)
+-- Loot pickup values — Sprint 8b: 4-tier medkit ladder (200 HP rebalance).
+-- Weapon drops remain removed (weapons are shop-only).
 GameConfig.LOOT = {
-	Ammo = { Amount = 15 },
-	Medkit = { Heal = 50 },
-	Coin = { Amount = 10 },
+	Ammo        = { Amount = 15 },
+	MedkitSmall = { Heal = 50 },   -- 25% HP regen, common (Patrol drop)
+	Medkit      = { Heal = 100 },  -- 50% HP regen, standard (Armored drop) — was Heal=50 in Sprint 7
+	MedkitLarge = { Heal = 150 },  -- 75% HP regen, rare (Elite drop)
+	MedkitFull  = { Heal = 200 },  -- full restore, ultra-rare (Elite 5% drop)
+	Coin        = { Amount = 10 },
 }
 
 return GameConfig

--- a/src/ServerScriptService/LootSystem.lua
+++ b/src/ServerScriptService/LootSystem.lua
@@ -20,10 +20,17 @@ local function createPickup(lootType, position)
 	part.Position = position + Vector3.new(0, 2, 0)
 	part:SetAttribute("LootType", lootType)
 
+	-- Sprint 8b: 4-tier medkit colors (light → standard → deep green → off-white for full)
 	if lootType == "Ammo" then
 		part.Color = Color3.fromRGB(255, 200, 50)
+	elseif lootType == "MedkitSmall" then
+		part.Color = Color3.fromRGB(120, 255, 150)  -- light green (50 HP)
 	elseif lootType == "Medkit" then
-		part.Color = Color3.fromRGB(50, 255, 100)
+		part.Color = Color3.fromRGB(50, 255, 100)   -- standard green (100 HP)
+	elseif lootType == "MedkitLarge" then
+		part.Color = Color3.fromRGB(20, 200, 80)    -- deep green (150 HP)
+	elseif lootType == "MedkitFull" then
+		part.Color = Color3.fromRGB(255, 255, 200)  -- off-white (full restore, 200 HP)
 	elseif lootType == "Coin" then
 		part.Color = Color3.fromRGB(255, 215, 0)
 	end
@@ -60,8 +67,13 @@ local function createPickup(lootType, position)
 		if lootType == "Ammo" then
 			data.Ammo = data.Ammo + GameConfig.LOOT.Ammo.Amount
 			events.AmmoUpdate:FireClient(player, data.Ammo, 30)
-		elseif lootType == "Medkit" then
-			mm.healPlayer(player, GameConfig.LOOT.Medkit.Heal)
+		elseif lootType == "MedkitSmall" or lootType == "Medkit"
+		    or lootType == "MedkitLarge" or lootType == "MedkitFull" then
+			-- Sprint 8b: 4-tier medkit; heal amount lookup from GameConfig.LOOT[tier].Heal
+			local entry = GameConfig.LOOT[lootType]
+			if entry and entry.Heal then
+				mm.healPlayer(player, entry.Heal)
+			end
 		elseif lootType == "Coin" then
 			data.Coins = data.Coins + GameConfig.LOOT.Coin.Amount
 		end

--- a/src/ServerScriptService/MatchManager.lua
+++ b/src/ServerScriptService/MatchManager.lua
@@ -522,10 +522,19 @@ events:WaitForChild("FireWeapon").OnServerEvent:Connect(function(player, origin,
 			local hitHumanoid = hitChar and hitChar:FindFirstChildOfClass("Humanoid")
 
 			if hitHumanoid then
+				-- Sprint 8b D1: Sniper Type only — hitting Head part applies headshot multiplier.
+				-- Other Types (Pistol/SMG/Rifle/Shotgun/Knife/Minigun) deal flat Damage on Head hit.
+				-- Strict "Head part only" — NPC hat/hood/helmet accessories don't count (deflected).
+				local damage = config.Damage
+				local isHeadshot = hitPart.Name == "Head"
+				if config.Type == "Sniper" and isHeadshot then
+					damage = damage * GameConfig.HEADSHOT_MULTIPLIER
+				end
+
 				-- Check if it's a player
 				local hitPlayer = Players:GetPlayerFromCharacter(hitChar)
 				if hitPlayer then
-					MatchManager.damagePlayer(hitPlayer, config.Damage, player)
+					MatchManager.damagePlayer(hitPlayer, damage, player)
 				else
 					-- It's an NPC - let NPCSystem handle death via HP attribute listener.
 					-- Stamp LastAttackerId so NPCSystem.dropLoot can credit the kill bonus
@@ -533,11 +542,11 @@ events:WaitForChild("FireWeapon").OnServerEvent:Connect(function(player, origin,
 					-- can't be stored in attributes.
 					local npcHP = hitChar:GetAttribute("HP")
 					if npcHP then
-						npcHP = npcHP - config.Damage
+						npcHP = npcHP - damage
 						hitChar:SetAttribute("HP", npcHP)
 						hitChar:SetAttribute("LastAttackerId", player.UserId)
 						-- Tell clients to flash the NPC and float a damage number
-						events.NPCDamaged:FireAllClients(hitChar, config.Damage, result.Position)
+						events.NPCDamaged:FireAllClients(hitChar, damage, result.Position)
 					end
 				end
 			end

--- a/src/ServerScriptService/NPCSystem.lua
+++ b/src/ServerScriptService/NPCSystem.lua
@@ -226,16 +226,20 @@ local function dropLoot(npcModel)
 			loot.Shape = Enum.PartType.Ball
 			loot:SetAttribute("LootType", lootType)
 
-			-- Color by type
+			-- Sprint 8b: 4-tier medkit colors match LootSystem.createPickup
+			loot.Material = Enum.Material.Neon
 			if lootType == "Ammo" then
 				loot.Color = Color3.fromRGB(255, 200, 50)
-				loot.Material = Enum.Material.Neon
+			elseif lootType == "MedkitSmall" then
+				loot.Color = Color3.fromRGB(120, 255, 150)
 			elseif lootType == "Medkit" then
 				loot.Color = Color3.fromRGB(50, 255, 100)
-				loot.Material = Enum.Material.Neon
+			elseif lootType == "MedkitLarge" then
+				loot.Color = Color3.fromRGB(20, 200, 80)
+			elseif lootType == "MedkitFull" then
+				loot.Color = Color3.fromRGB(255, 255, 200)
 			elseif lootType == "Coin" then
 				loot.Color = Color3.fromRGB(255, 215, 0)
-				loot.Material = Enum.Material.Neon
 			end
 
 			-- Glow
@@ -260,8 +264,13 @@ local function dropLoot(npcModel)
 				if lootType == "Ammo" then
 					data.Ammo = data.Ammo + GameConfig.LOOT.Ammo.Amount
 					events.AmmoUpdate:FireClient(player, data.Ammo, 30)
-				elseif lootType == "Medkit" then
-					mm.healPlayer(player, GameConfig.LOOT.Medkit.Heal)
+				elseif lootType == "MedkitSmall" or lootType == "Medkit"
+				    or lootType == "MedkitLarge" or lootType == "MedkitFull" then
+					-- Sprint 8b: 4-tier medkit; heal amount lookup
+					local entry = GameConfig.LOOT[lootType]
+					if entry and entry.Heal then
+						mm.healPlayer(player, entry.Heal)
+					end
 				elseif lootType == "Coin" then
 					data.Coins = data.Coins + GameConfig.LOOT.Coin.Amount
 				end

--- a/src/StarterPlayerScripts/HUDController.lua
+++ b/src/StarterPlayerScripts/HUDController.lua
@@ -9,6 +9,7 @@ local ReplicatedStorage = game:GetService("ReplicatedStorage")
 
 local player = Players.LocalPlayer
 local events = ReplicatedStorage:WaitForChild("GameEvents")
+local GameConfig = require(ReplicatedStorage:WaitForChild("GameConfig"))
 
 -- ====== CREATE HUD ======
 -- Main HUD ScreenGui keeps the default IgnoreGuiInset=false so existing widgets
@@ -49,7 +50,7 @@ local hpText = Instance.new("TextLabel")
 hpText.Name = "HPText"
 hpText.Size = UDim2.new(1, 0, 1, 0)
 hpText.BackgroundTransparency = 1
-hpText.Text = "100 / 100"
+hpText.Text = GameConfig.MAX_HP .. " / " .. GameConfig.MAX_HP  -- Sprint 8b: 200 HP
 hpText.TextColor3 = Color3.fromRGB(255, 255, 255)
 hpText.TextScaled = true
 hpText.Font = Enum.Font.GothamBold

--- a/workloads/03-player-health.yaml
+++ b/workloads/03-player-health.yaml
@@ -1,7 +1,8 @@
 name: PlayerHealth
 owner: claude-code
 priority: P0-prototype
-status: ✅ DONE (Sprint 2) | 🔄 REBALANCE PLANNED (Sprint 8b — 200 HP)
+status: ✅ DONE (Sprint 2) | ✅ REBALANCED (Sprint 8b — 200 HP, 2026-05-03)
+sprint_8b_receipt: receipts/sprint-8b-200hp-rebalance.md
 
 # ============= Sprint 8b 計劃中的修改（CEO 決議 b 後重寫 2026-05-03） =============
 # 詳見 proposals/sprint-8-200hp-balance.md

--- a/workloads/04-weapon-system.yaml
+++ b/workloads/04-weapon-system.yaml
@@ -1,7 +1,8 @@
 name: WeaponSystem
 owner: claude-code
 priority: P0-prototype
-status: ✅ DONE (Sprint 3 + Sprint 7 visual) | 🔄 REBALANCE PLANNED (Sprint 8)
+status: ✅ DONE (Sprint 3 + Sprint 7 visual + Sprint 8b 30-weapon retune + Sniper headshot, 2026-05-03)
+sprint_8b_receipt: receipts/sprint-8b-200hp-rebalance.md
 
 # ============= Sprint 8b 計劃中的修改（CEO 決議 b 後重寫 2026-05-03） =============
 # 詳見 proposals/sprint-8-200hp-balance.md §3.5 + §4.2

--- a/workloads/05-npc-system.yaml
+++ b/workloads/05-npc-system.yaml
@@ -1,7 +1,8 @@
 name: NPCSystem
 owner: claude-code
 priority: P0-prototype
-status: ✅ DONE (Sprint 3 + Sprint 7 R15 mesh) | 🔄 REBALANCE PLANNED (Sprint 8)
+status: ✅ DONE (Sprint 3 + Sprint 7 R15 mesh + Sprint 8b HP×2 + 4-tier medkit drops, 2026-05-03)
+sprint_8b_receipt: receipts/sprint-8b-200hp-rebalance.md
 
 # ============= Sprint 8 計劃中的修改 =============
 # 詳見 proposals/sprint-8-200hp-balance.md §4.3

--- a/workloads/06-loot-system.yaml
+++ b/workloads/06-loot-system.yaml
@@ -1,7 +1,8 @@
 name: LootSystem
 owner: claude-code
 priority: P1-polish
-status: ✅ DONE (Sprint 3) | 🔄 REBALANCE PLANNED (Sprint 8 — 4 階 medkit)
+status: ✅ DONE (Sprint 3 + Sprint 8b 4-tier medkit, 2026-05-03)
+sprint_8b_receipt: receipts/sprint-8b-200hp-rebalance.md
 
 # ============= Sprint 8 計劃中的修改 =============
 # 詳見 proposals/sprint-8-200hp-balance.md §4.4


### PR DESCRIPTION
## Summary

Sprint 8b 實作。實現 PR #25 (`proposals/30-weapon-dps-retune.md`) 已 CEO 拍板的全部設計。**這是 Code 改動**，前面的 PR #23 / #25 都是設計文件。

### 主要改動
- 玩家血量 100 → **200 HP**
- 30 武器 Damage 重平衡（DPS gap 從 3.0x → 1.9x）
- Sniper Type-based headshot（HEADSHOT_MULTIPLIER 2.0x）— 全 5 把 Wraith 系列爆頭 1-shot 200 HP 玩家
- NPC HP/Damage ×2（Patrol 120/18, Armored 300/28, Elite 500/40）
- 4 階補血包（Small 50 / Medkit 100 / Large 150 / Full 200）

## Files Changed (5 code + 4 contracts + 1 receipt)

### Implementation (commit 137c340)
- `src/ReplicatedStorage/GameConfig.lua` — MAX_HP, HEADSHOT_MULTIPLIER, RARITY 倍率, 30 武器 Damage, ENEMIES, LOOT
- `src/ServerScriptService/MatchManager.lua` — FireWeapon Sniper headshot 分支
- `src/ServerScriptService/NPCSystem.lua` — dropLoot 4 階 medkit 顏色 + Touched
- `src/ServerScriptService/LootSystem.lua` — createPickup 4 階 medkit 顏色 + Touched
- `src/StarterPlayerScripts/HUDController.lua` — 初始 hpText 從硬編碼 100 改為 GameConfig.MAX_HP

### Docs (commit 47dc4ef)
- `workloads/03-player-health.yaml` — status → ✅ DONE Sprint 8b
- `workloads/04-weapon-system.yaml` — status → ✅ DONE Sprint 8b (含 30 武器 retune + Sniper headshot)
- `workloads/05-npc-system.yaml` — status → ✅ DONE Sprint 8b
- `workloads/06-loot-system.yaml` — status → ✅ DONE Sprint 8b (4-tier medkit)
- `receipts/sprint-8b-200hp-rebalance.md` — 完整 receipt（驗證、known issues、lessons、Sprint 9 候選）

## Sniper Headshot D1 驗證

post-(b) Wraith body × 2.0x 對 200 HP 玩家：

| 武器 | Body | Headshot | vs 200 HP |
|---|---|---|---|
| Wraith Scout (Uncommon) | 120 | 240 | **1-shot ✓** |
| Wraith Hunter (Rare) | 172 | 344 | **1-shot ✓** |
| Wraith Frost (Epic) | 190 | 380 | **1-shot ✓** |
| Wraith Apex (Legendary) | 206 | 412 | **1-shot ✓** |
| Wraith Abyss (Demon) | 220 | 440 | **1-shot ✓** |

## DPS Gap Convergence 驗證

舉例：
- Pistol Common Viper Mk1: 30/0.40 = **75 DPS** ✓ baseline
- Knife Demon Fang Demon: 76/0.50 = **152 DPS** = Common Fang Scout 80 × **1.90** ✓
- Shotgun Demon Bloodmoon: 14×8/0.60 = **186.7 DPS** = Common Stub 14×6/0.85=98.8 × **1.89** ✓
- Sniper Demon Wraith Abyss: 220/1.05 = **209.5 DPS** ≈ 110 × 1.90 ✓

整體 Common→Demon DPS gap 從 3.0x **收斂到 1.9x**（付費差距 ↓ 37%）。

## Test plan

- [ ] Studio MCP playtest：單人跑一輪 PvE
  - 200 HP 起始，HUD 顯示 "200 / 200"
  - Patrol 站樁攻擊 → 玩家從 200 HP 降到 0 約 11.1s（vs 現在 5s）
  - Phantom Ranger (19 dmg) 對 Patrol (120 HP) 殺敵時間
  - **Wraith Scout 爆頭 R15 NPC.Head → console 顯示 240 dmg（NPCDamaged event）**
  - **Wraith Scout 身體 → console 顯示 120 dmg**
  - 4 階 medkit pickup 顏色目視差異（淺綠 → 標準綠 → 深綠 → 米白）
- [ ] Edge case: NPC 戴帽子命中時 hitPart.Name 確認不是 "Head"（不算爆頭）
- [ ] Edge case: 其他 Type（Pistol/SMG/Rifle/Shotgun/Knife/Minigun）命中 Head 不加成

## Reviewer 重點

1. Sniper headshot 邏輯（MatchManager.lua FireWeapon handler）— Type-based 而非寫死武器名
2. 30 武器 Damage 數值是否與 `proposals/30-weapon-dps-retune.md` §9 template 完全一致
3. NPC LootTable 與 LOOT 配置是否對齊 workloads/05 + workloads/06

🤖 Generated with [Claude Code](https://claude.com/claude-code)