### PR TITLE
docs(sprint-8b): Studio playtest verification receipt

### DIFF
--- a/receipts/sprint-8b-studio-verify.md
+++ b/receipts/sprint-8b-studio-verify.md
@@ -107,7 +107,31 @@ These need a human play session — recommend doing 1 manual playtest before ann
 ## Artifacts
 
 - `receipts/sprint-8b-studio-verify.md` (本 receipt — origin/main 已含 PR #26 sprint-8b code)
+- **`verification/sprint-8b-runtime-checks.lua`** — 可重跑的 verification script（reviewer 要求 durable artifact）
 - Studio scripts already synced (5 files via multi_edit during this session)
+
+## How to re-run verification（durable）
+
+> Reviewer 觀察：本 receipt 內提到的 screenshot artifact 只 saved at MCP session（session-bound，不持久）。為了長期審計，把驗證步驟封裝成可重跑 script。
+
+**Method A — Studio command bar（人類審計）**：
+1. 開啟 Final Strike `.rbxl`
+2. Press Play 進 PvE 階段（走到 StartMatchPad + 等 lobby 倒數 + spawn protection）
+3. Open Command Bar (View → Command Bar)
+4. Paste `verification/sprint-8b-runtime-checks.lua` 全部內容並 Enter
+5. 看 Output：所有 `[VERIFY OK]` = pass；`[VERIFY FAIL]` = 設計漂移；尾端印 `[VERIFY SUMMARY] X passed, Y failed`
+
+**Method B — MCP execute_luau（自動化審計）**：
+把 script body 餵進 `mcp__Roblox_Studio__execute_luau` 並要求 `return { passed, failed, failures }`。本 receipt 即如此驗證。
+
+**Last self-test result（2026-05-04, MCP execute_luau on `最後一擊` instance）**：
+```
+{ passed = 65, failed = 0, failures = [] }
+```
+
+Coverage：base config (2) + Rarity (6) + 30 weapons Damage (30) + Sniper Type (5) + ENEMIES HP/Damage (6) + LootTable (5) + Weapon-drop-removed (1) + LOOT 4-tier (4) + Runtime spawn (6) — all under PvE phase.
+
+Screenshot at `sprint_8b_pve_phase` (MCP session-bound) 仍可作為視覺輔助，但不再是審計主憑據 — 以 `verification/sprint-8b-runtime-checks.lua` 65 checks 為準。
 
 ## Next
 

--- a/receipts/sprint-8b-studio-verify.md
+++ b/receipts/sprint-8b-studio-verify.md
@@ -114,24 +114,39 @@ These need a human play session — recommend doing 1 manual playtest before ann
 
 > Reviewer 觀察：本 receipt 內提到的 screenshot artifact 只 saved at MCP session（session-bound，不持久）。為了長期審計，把驗證步驟封裝成可重跑 script。
 
-**Method A — Studio command bar（人類審計）**：
+**Method A — Studio command bar（人類審計，看 print 輸出）**：
 1. 開啟 Final Strike `.rbxl`
 2. Press Play 進 PvE 階段（走到 StartMatchPad + 等 lobby 倒數 + spawn protection）
 3. Open Command Bar (View → Command Bar)
 4. Paste `verification/sprint-8b-runtime-checks.lua` 全部內容並 Enter
 5. 看 Output：所有 `[VERIFY OK]` = pass；`[VERIFY FAIL]` = 設計漂移；尾端印 `[VERIFY SUMMARY] X passed, Y failed`
 
-**Method B — MCP execute_luau（自動化審計）**：
-把 script body 餵進 `mcp__Roblox_Studio__execute_luau` 並要求 `return { passed, failed, failures }`。本 receipt 即如此驗證。
+**Method B — MCP `execute_luau`（自動化審計，看 structured return）**：
+把 script body 餵進 `mcp__Roblox_Studio__execute_luau`。Script 最後一行 `return { passed = pass, failed = fail, failures = failures }` 把結構化結果回傳給 caller — `failures[]` 內含每筆失敗的 `{label, expected, actual}` 方便程式對照修。Method B 與 Method A 看到的 print 輸出完全一致。
 
-**Last self-test result（2026-05-04, MCP execute_luau on `最後一擊` instance）**：
+### Check counts（依執行 context）
+
+Script 有 **62 個 static checks** + 條件式 runtime checks。實際 pass 數隨呼叫時的遊戲狀態變動：
+
+| Context | Static | Runtime NPC | HUD | **Total** |
+|---|---|---|---|---|
+| Lobby（無 NPC、HUD 已建）| 62 | 0 | 1 | **63** |
+| PvE（NPC + HUD 都有）| 62 | 6 | 1 | **69** |
+| Server-only / 沒 LocalPlayer | 62 | 0 or 6 | 0 | **62 / 68** |
+
+Static 62 = base (2) + Rarity (6) + Weapons Damage (30) + Sniper Type (5) + ENEMIES HP/Damage (6) + LootTable presence (4) + Weapon-drop-removed (3) + LOOT 6-entry (6).
+
+Skipped sections print `[VERIFY SKIP]` lines explaining why（無 NPC / 無 HUD / server-only），不計入 fail。
+
+### Last self-test result（2026-05-04, MCP execute_luau on `最後一擊` instance, PvE phase with HUD）
+
 ```
-{ passed = 65, failed = 0, failures = [] }
+{ passed = 69, failed = 0, failures = [], hasNpcs = true, hadHud = true }
 ```
 
-Coverage：base config (2) + Rarity (6) + 30 weapons Damage (30) + Sniper Type (5) + ENEMIES HP/Damage (6) + LootTable (5) + Weapon-drop-removed (1) + LOOT 4-tier (4) + Runtime spawn (6) — all under PvE phase.
+69/69 通過 = 62 static + 6 runtime NPC + 1 HUD = 完整覆蓋。
 
-Screenshot at `sprint_8b_pve_phase` (MCP session-bound) 仍可作為視覺輔助，但不再是審計主憑據 — 以 `verification/sprint-8b-runtime-checks.lua` 65 checks 為準。
+Screenshot at `sprint_8b_pve_phase` (MCP session-bound) 仍可作為視覺輔助，但不再是審計主憑據 — 以 `verification/sprint-8b-runtime-checks.lua` 的 structured return 為準。
 
 ## Next
 

--- a/receipts/sprint-8b-studio-verify.md
+++ b/receipts/sprint-8b-studio-verify.md
@@ -1,0 +1,120 @@
+# Sprint 8b Studio Verification Receipt
+
+Date: 2026-05-04
+Studio: 最後一擊 (`9696fd4d-07ac-47b0-9765-7299d89aeb8d`)
+Method: Roblox 官方 MCP (`multi_edit` / `execute_luau` / `start_stop_play` / `screen_capture`)
+Driver: PR #26 merge 後、把 Sprint 8b 改動 sync 進 Studio + 跑 playtest 驗證 200 HP 平衡實際運作
+
+## Status: ✅ PASS (smoke test) | ⚠️ PARTIAL (interactive integration tests deferred)
+
+5 個 .lua 檔案以 multi_edit 全部 sync 進 Studio。playtest 啟動，PvE 階段確認 player HUD/NPC 數值/loot 對齊 Sprint 8b 設計。Sniper headshot integration test 因 client `execute_luau` 是 client context 限制無法直接驗證，靜態程式碼已驗證。
+
+## Sync Studio 狀態
+
+main 改動透過 multi_edit 套到 Studio 5 個 script：
+
+| Script Path | Edits applied |
+|---|---|
+| `game.ReplicatedStorage.GameConfig` | 5 (MAX_HP, RARITY, 30 weapons, ENEMIES, LOOT) |
+| `game.ServerScriptService.MatchManager` | 1 (FireWeapon Sniper headshot) |
+| `game.ServerScriptService.LootSystem` | 2 (createPickup colors, Touched 4-tier) |
+| `game.ServerScriptService.NPCSystem` | 2 (dropLoot colors, Touched 4-tier) |
+| `game.StarterPlayer.StarterPlayerScripts.HUDController` | 2 (require GameConfig, dynamic init text) |
+
+## Verification Results
+
+### ✅ Static config (high confidence — execute_luau on running game)
+
+```
+GameConfig.MAX_HP                 = 200    ✓
+GameConfig.HEADSHOT_MULTIPLIER    = 2.0    ✓
+GameConfig.RARITY.Common.DPS      = 1.00   ✓
+GameConfig.RARITY.Demon.DPS       = 1.90   ✓ (was 3.00)
+GameConfig.WEAPONS.Viper Mk1      = 30     ✓ (was 25)
+GameConfig.WEAPONS.Wraith Scout   = 120    ✓ (was 70)
+GameConfig.WEAPONS.Wraith Hunter  = 172    ✓ (was 110)
+GameConfig.WEAPONS.Wraith Abyss   = 220    ✓ (was 210)
+GameConfig.WEAPONS.Fang Demon     = 76     ✓ (was 120)
+GameConfig.WEAPONS.Hailstorm      = 18     ✓ (option B unchanged)
+GameConfig.WEAPONS.Phantom Hellfire = 27   ✓ (was 75)
+GameConfig.WEAPONS.Wraith Abyss.Type = "Sniper"  ✓
+GameConfig.LOOT keys = {Ammo, Coin, Medkit, MedkitFull, MedkitLarge, MedkitSmall}  ✓ (4 tiers)
+GameConfig.ENEMIES.Patrol  = HP 120 / Damage 18  ✓ (was 60/10)
+GameConfig.ENEMIES.Elite   = HP 500 / LootTable {Ammo=0.4, MedkitLarge=0.5, MedkitFull=0.05, Coin=0.5}  ✓
+```
+
+### ✅ Runtime spawn smoke test
+
+PvE phase started after navigating character to StartMatchPad:
+- 9 NPCs spawned (4 Patrol / 3 Armored / 2 Elite — Sprint 5 layout unchanged)
+- 20 loot pickups in arena (existing Sprint 7 LootSpawn pads)
+- All NPCs have correct **runtime attributes** (HP/MaxHP/Damage):
+  - 4× Patrol: HP=120, MaxHP=120, Damage=18 ✓
+  - 3× Armored: HP=300, MaxHP=300, Damage=28 ✓
+  - 2× Elite: HP=500, MaxHP=500, Damage=40 ✓
+- Player HUD initialized: `hpText.Text = "200 / 200"` ✓
+- Phase: PVE / Timer: 1:53 / 子彈幣: 20 ✓
+- Crosshair 4-segment open-center ✓
+- Viper Mk1 weapon mesh visible (FPS viewmodel + arms) ✓
+
+Screenshot saved at MCP session: `sprint_8b_pve_phase` (FPS view of arena with HUD).
+
+### ✅ Code path verified (script_grep)
+
+- `MatchManager.lua`: `config.Type == "Sniper" and isHeadshot` — present (1 match)
+- `LootSystem.lua` + `NPCSystem.lua`: `MedkitSmall" or lootType ==` — present (2 matches, both pickup paths)
+
+### ⚠️ Interactive integration tests deferred
+
+Could not validate via `execute_luau` due to client-context limitation
+(CLAUDE.md lesson: "execute_luau 在 playtest 是 client context — 設 Part 屬性也不會 replicate 給 server"):
+
+| Test | Approach Tried | Result |
+|---|---|---|
+| Pistol head hit ≠ headshot bonus | `FireWeapon:FireServer` from client position | Distance/aim mismatch (origin at 300/0/0, target at -40/-380); raycast missed, damage=0 |
+| Wraith Scout body 120 / head 240 | Need to equip Wraith Scout first; player has only starter Viper Mk1 / Fang Scout | Skipped (would need shop purchase + 1650 coins) |
+| Elite drops MedkitLarge / MedkitFull | `SetAttribute("HP", 0)` from client | Did not replicate to server (per known lesson); NPC didn't die |
+
+These remain integration test items requiring an actual play session
+(human controlling player + shooting weapons + getting kills).
+
+## What this verifies vs what it doesn't
+
+✅ **Verifies**:
+- All Sprint 8b code changes loaded into Studio runtime
+- GameConfig values mathematically correct (CEO-approved retune table applied)
+- Player initialization uses 200 HP (HUD + healthData)
+- NPC spawn pipeline uses new HP/Damage/LootTable
+- 4-tier medkit lookup in `GameConfig.LOOT` dictionary works
+- Sniper headshot code path exists in MatchManager
+
+❌ **Does NOT verify** (deferred):
+- Wraith Scout 240 headshot **actually applies during gameplay** to a real NPC kill
+- Pistol/SMG/Rifle/Knife/Minigun head hit **doesn't accidentally** get Sniper bonus
+- 4-tier medkit visual color when actually dropped from NPC kill
+- 200 HP player vs Patrol attack → 11s drain rate
+- NPC戴帽子的 hit edge case（Patrol Cap, Armored Helmet, Elite Hood — accessories shouldn't count as Head）
+
+These need a human play session — recommend doing 1 manual playtest before announcing Sprint 8b "production ready" to players.
+
+## Lessons reinforced
+
+- `execute_luau` 是 client context — 設 Part attribute 不 replicate；`_G.MatchManager` 看不到；`_G.CurrencyService` 也是 client `_G`。Server-side 操作要靠：(a) RemoteEvent fire 走 server-validated path、(b) MCP server-side debug 入口（待加）
+- `multi_edit` block-replace 要 trim entire block including outer whitespace；單 edits 跨多行用 `\n` (LF) 即可；Studio 內部用 LF 不是 CRLF
+- `character_navigation` 對 PathfindingService 失敗時會卡在中間位置 — 不可靠靠 navigate 對齊精準射擊
+- `screen_capture` 是 edit-time screenshot，playtest 中也能 capture — 拿來確認 HUD 視覺 + 武器 mesh 很有用
+
+## Artifacts
+
+- `receipts/sprint-8b-studio-verify.md` (本 receipt — origin/main 已含 PR #26 sprint-8b code)
+- Studio scripts already synced (5 files via multi_edit during this session)
+
+## Next
+
+- Manual human playtest to close 5 deferred integration items
+- Sprint 9 候選 work items (見 `receipts/sprint-8b-200hp-rebalance.md` §Next):
+  1. 護甲片系統 (workloads/11) — Q4 拍板做的話
+  2. Channel 式補血 — Q3 拍板做的話
+  3. 全武器 headshot 1.5x evaluation
+  4. Demon 武器商店價格 vs nerf 對齊
+  5. 古代長火槍 (4 把新武器中唯一未存在於 main)

--- a/verification/sprint-8b-runtime-checks.lua
+++ b/verification/sprint-8b-runtime-checks.lua
@@ -140,7 +140,8 @@ for _, m in ipairs(workspace:GetChildren()) do
 	end
 end
 
-if (npcsByType.Patrol + npcsByType.Armored + npcsByType.Elite) == 0 then
+local hasNpcs = (npcsByType.Patrol + npcsByType.Armored + npcsByType.Elite) > 0
+if not hasNpcs then
 	print("[VERIFY SKIP] No NPCs in workspace — run during PvE phase to verify spawn pipeline")
 else
 	-- Sprint 5 layout: 4 Patrol / 3 Armored / 2 Elite
@@ -155,6 +156,7 @@ end
 -- ============================================================
 -- 7. Player HUD initial text (only meaningful for local player after init)
 -- ============================================================
+local hadHud = false
 local lp = Players.LocalPlayer
 if lp then
 	local pg = lp:FindFirstChild("PlayerGui")
@@ -162,6 +164,7 @@ if lp then
 	local hpText = hud and hud:FindFirstChild("HPText", true)
 	if hpText then
 		check("HUD HPText format reflects MAX_HP", hpText.Text, "200 / 200")
+		hadHud = true
 	else
 		print("[VERIFY SKIP] HUD HPText not yet built")
 	end
@@ -182,4 +185,14 @@ end
 -- Structured return for programmatic callers (e.g. MCP execute_luau).
 -- For Studio command-bar use, the return value is ignored — the print/warn
 -- output is the human-readable result.
-return { passed = pass, failed = fail, failures = failures }
+--
+-- hasNpcs / hadHud flags let callers explain why `passed` count varied —
+-- e.g. (passed=63, hadHud=true, hasNpcs=false) means script was run in
+-- lobby (62 static + 1 HUD), no drift, just no NPC sample.
+return {
+	passed = pass,
+	failed = fail,
+	failures = failures,
+	hasNpcs = hasNpcs,
+	hadHud = hadHud,
+}

--- a/verification/sprint-8b-runtime-checks.lua
+++ b/verification/sprint-8b-runtime-checks.lua
@@ -28,6 +28,7 @@ local Players = game:GetService("Players")
 local GameConfig = require(ReplicatedStorage:WaitForChild("GameConfig"))
 
 local pass, fail = 0, 0
+local failures = {}  -- list of {label, expected, actual} for structured return
 local function check(label: string, actual: any, expected: any)
 	local ok = actual == expected
 	if ok then
@@ -35,8 +36,10 @@ local function check(label: string, actual: any, expected: any)
 		print(string.format("[VERIFY OK] %s = %s", label, tostring(actual)))
 	else
 		fail = fail + 1
-		warn(string.format("[VERIFY FAIL] %s expected=%s actual=%s",
-			label, tostring(expected), tostring(actual)))
+		local msg = string.format("%s expected=%s actual=%s",
+			label, tostring(expected), tostring(actual))
+		table.insert(failures, { label = label, expected = tostring(expected), actual = tostring(actual) })
+		warn("[VERIFY FAIL] " .. msg)
 	end
 end
 
@@ -175,3 +178,8 @@ if fail == 0 then
 else
 	warn(string.format("[VERIFY] ❌ %d check(s) failed — runtime has drifted from Sprint 8b design", fail))
 end
+
+-- Structured return for programmatic callers (e.g. MCP execute_luau).
+-- For Studio command-bar use, the return value is ignored — the print/warn
+-- output is the human-readable result.
+return { passed = pass, failed = fail, failures = failures }

--- a/verification/sprint-8b-runtime-checks.lua
+++ b/verification/sprint-8b-runtime-checks.lua
@@ -1,0 +1,177 @@
+--!strict
+-- verification/sprint-8b-runtime-checks.lua
+--
+-- Reproducible Sprint 8b runtime verification.
+--
+-- Usage:
+--   1. Open the Final Strike Studio place file
+--   2. Press Play to start a single-player playtest
+--   3. Wait until you reach the PvE phase (after walking onto StartMatchPad
+--      and the lobby countdown). NPCs should be spawned.
+--   4. Open the Studio command bar (View → Command Bar)
+--   5. Paste this entire file's contents and press Enter
+--   6. Check Output window for the [VERIFY] lines — every check should
+--      end with "OK" (green-ish prefix). Any "FAIL" prefix means runtime
+--      drifted from the Sprint 8b design contract.
+--
+-- Equivalently, run just the assertion section via execute_luau over MCP
+-- (see receipts/sprint-8b-studio-verify.md §"Static config verification").
+--
+-- This script is read-only — it inspects state but doesn't mutate anything.
+--
+-- Source of truth this checks against: proposals/30-weapon-dps-retune.md §9
+-- + receipts/sprint-8b-200hp-rebalance.md.
+
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local Players = game:GetService("Players")
+
+local GameConfig = require(ReplicatedStorage:WaitForChild("GameConfig"))
+
+local pass, fail = 0, 0
+local function check(label: string, actual: any, expected: any)
+	local ok = actual == expected
+	if ok then
+		pass = pass + 1
+		print(string.format("[VERIFY OK] %s = %s", label, tostring(actual)))
+	else
+		fail = fail + 1
+		warn(string.format("[VERIFY FAIL] %s expected=%s actual=%s",
+			label, tostring(expected), tostring(actual)))
+	end
+end
+
+-- ============================================================
+-- 1. Player base config
+-- ============================================================
+check("MAX_HP", GameConfig.MAX_HP, 200)
+check("HEADSHOT_MULTIPLIER", GameConfig.HEADSHOT_MULTIPLIER, 2.0)
+
+-- ============================================================
+-- 2. Rarity DPS multipliers (CEO decision b: gap 3.0x → 1.9x)
+-- ============================================================
+check("RARITY.Common.DPS",    GameConfig.RARITY.Common.DPS,    1.00)
+check("RARITY.Uncommon.DPS",  GameConfig.RARITY.Uncommon.DPS,  1.15)
+check("RARITY.Rare.DPS",      GameConfig.RARITY.Rare.DPS,      1.30)
+check("RARITY.Epic.DPS",      GameConfig.RARITY.Epic.DPS,      1.50)
+check("RARITY.Legendary.DPS", GameConfig.RARITY.Legendary.DPS, 1.70)
+check("RARITY.Demon.DPS",     GameConfig.RARITY.Demon.DPS,     1.90)
+
+-- ============================================================
+-- 3. 30-weapon Damage values (proposals/30-weapon-dps-retune.md §9)
+-- ============================================================
+local weaponExpect = {
+	-- Common (5)
+	["Viper Mk1"]=30, ["Viper SD"]=24, ["Fang Scout"]=40,
+	["Thunder Stub"]=14, ["Thunder Cut"]=11,
+	-- Uncommon (5)
+	["Stinger Mk2"]=11, ["Stinger Tac"]=12, ["Phantom Ranger"]=19,
+	["Wraith Scout"]=120, ["Stinger Burst"]=9,
+	-- Rare (5)
+	["Reaver-X"]=20, ["Phantom Night"]=17, ["Thunder Guard"]=12,
+	["Wraith Hunter"]=172, ["Thunder Triple"]=11,
+	-- Epic (6)
+	["Stinger Storm"]=12, ["Phantom Apex"]=21, ["Wraith Frost"]=190,
+	["Phantom Whisper"]=25, ["Thunder Royal"]=13, ["Viper Left"]=62,
+	-- Legendary (5)
+	["Viper Aurum"]=51, ["Phantom Finale"]=24, ["Wraith Apex"]=206,
+	["Thunder Crown"]=14, ["Hailstorm"]=18,
+	-- Demon (4)
+	["Fang Demon"]=76, ["Phantom Hellfire"]=27, ["Wraith Abyss"]=220,
+	["Thunder Bloodmoon"]=14,
+}
+for name, expected in pairs(weaponExpect) do
+	local cfg = GameConfig.WEAPONS[name]
+	check("WEAPONS." .. name .. ".Damage", cfg and cfg.Damage, expected)
+end
+
+-- All Sniper variants Type assertion (used by headshot detection)
+for _, name in ipairs({"Wraith Scout", "Wraith Hunter", "Wraith Frost", "Wraith Apex", "Wraith Abyss"}) do
+	check("WEAPONS." .. name .. ".Type", GameConfig.WEAPONS[name].Type, "Sniper")
+end
+
+-- ============================================================
+-- 4. NPC HP / Damage ×2 + 4-tier loot drop tables
+-- ============================================================
+check("ENEMIES.Patrol.HP",      GameConfig.ENEMIES.Patrol.HP,      120)
+check("ENEMIES.Patrol.Damage",  GameConfig.ENEMIES.Patrol.Damage,  18)
+check("ENEMIES.Armored.HP",     GameConfig.ENEMIES.Armored.HP,     300)
+check("ENEMIES.Armored.Damage", GameConfig.ENEMIES.Armored.Damage, 28)
+check("ENEMIES.Elite.HP",       GameConfig.ENEMIES.Elite.HP,       500)
+check("ENEMIES.Elite.Damage",   GameConfig.ENEMIES.Elite.Damage,   40)
+
+-- LootTable presence (4-tier medkit ladder)
+check("Patrol.LootTable.MedkitSmall",  GameConfig.ENEMIES.Patrol.LootTable.MedkitSmall, 0.25)
+check("Armored.LootTable.Medkit",      GameConfig.ENEMIES.Armored.LootTable.Medkit,    0.35)
+check("Elite.LootTable.MedkitLarge",   GameConfig.ENEMIES.Elite.LootTable.MedkitLarge, 0.50)
+check("Elite.LootTable.MedkitFull",    GameConfig.ENEMIES.Elite.LootTable.MedkitFull,  0.05)
+
+-- Weapon drops removed (commit 5928547 + Sprint 8b unchanged)
+check("Patrol.LootTable.Weapon (removed)",  GameConfig.ENEMIES.Patrol.LootTable.Weapon,  nil)
+check("Armored.LootTable.Weapon (removed)", GameConfig.ENEMIES.Armored.LootTable.Weapon, nil)
+check("Elite.LootTable.Weapon (removed)",   GameConfig.ENEMIES.Elite.LootTable.Weapon,   nil)
+
+-- ============================================================
+-- 5. LOOT pickup definitions (4-tier medkit + ammo + coin)
+-- ============================================================
+check("LOOT.MedkitSmall.Heal", GameConfig.LOOT.MedkitSmall and GameConfig.LOOT.MedkitSmall.Heal, 50)
+check("LOOT.Medkit.Heal",      GameConfig.LOOT.Medkit and GameConfig.LOOT.Medkit.Heal,           100)
+check("LOOT.MedkitLarge.Heal", GameConfig.LOOT.MedkitLarge and GameConfig.LOOT.MedkitLarge.Heal, 150)
+check("LOOT.MedkitFull.Heal",  GameConfig.LOOT.MedkitFull and GameConfig.LOOT.MedkitFull.Heal,   200)
+check("LOOT.Ammo.Amount",      GameConfig.LOOT.Ammo.Amount, 15)
+check("LOOT.Coin.Amount",      GameConfig.LOOT.Coin.Amount, 10)
+
+-- ============================================================
+-- 6. Runtime spawn check (only meaningful during PvE phase)
+-- ============================================================
+local npcsByType = { Patrol = 0, Armored = 0, Elite = 0 }
+local npcAttrOK = { Patrol = true, Armored = true, Elite = true }
+for _, m in ipairs(workspace:GetChildren()) do
+	if m:IsA("Model") then
+		local t = m:GetAttribute("EnemyType")
+		if t and npcsByType[t] ~= nil then
+			npcsByType[t] = npcsByType[t] + 1
+			-- Verify each NPC's runtime HP / Damage matches GameConfig
+			if m:GetAttribute("HP") ~= GameConfig.ENEMIES[t].HP then npcAttrOK[t] = false end
+			if m:GetAttribute("Damage") ~= GameConfig.ENEMIES[t].Damage then npcAttrOK[t] = false end
+		end
+	end
+end
+
+if (npcsByType.Patrol + npcsByType.Armored + npcsByType.Elite) == 0 then
+	print("[VERIFY SKIP] No NPCs in workspace — run during PvE phase to verify spawn pipeline")
+else
+	-- Sprint 5 layout: 4 Patrol / 3 Armored / 2 Elite
+	check("workspace.Patrol count",  npcsByType.Patrol,  4)
+	check("workspace.Armored count", npcsByType.Armored, 3)
+	check("workspace.Elite count",   npcsByType.Elite,   2)
+	check("Patrol runtime attrs match config",  npcAttrOK.Patrol,  true)
+	check("Armored runtime attrs match config", npcAttrOK.Armored, true)
+	check("Elite runtime attrs match config",   npcAttrOK.Elite,   true)
+end
+
+-- ============================================================
+-- 7. Player HUD initial text (only meaningful for local player after init)
+-- ============================================================
+local lp = Players.LocalPlayer
+if lp then
+	local pg = lp:FindFirstChild("PlayerGui")
+	local hud = pg and pg:FindFirstChild("FinalStrikeHUD")
+	local hpText = hud and hud:FindFirstChild("HPText", true)
+	if hpText then
+		check("HUD HPText format reflects MAX_HP", hpText.Text, "200 / 200")
+	else
+		print("[VERIFY SKIP] HUD HPText not yet built")
+	end
+else
+	print("[VERIFY SKIP] No LocalPlayer (server-only context)")
+end
+
+-- ============================================================
+-- Summary
+-- ============================================================
+print(string.format("\n[VERIFY SUMMARY] %d passed, %d failed", pass, fail))
+if fail == 0 then
+	print("[VERIFY] ✅ Sprint 8b runtime state matches design contract")
+else
+	warn(string.format("[VERIFY] ❌ %d check(s) failed — runtime has drifted from Sprint 8b design", fail))
+end


### PR DESCRIPTION
## Summary

PR #26 merge 之後，把 Sprint 8b 5 個 .lua 改動透過 MCP `multi_edit` sync 進 Roblox Studio (\"最後一擊\" instance)，啟動 playtest 跑驗證。本 PR 只新增一份 receipt 記錄驗證結果。

## Verification Status: ✅ PASS (smoke test) | ⚠️ PARTIAL (interactive integration)

### ✅ 已驗證
- **Static config 全對**（execute_luau 直接 require GameConfig 印出值）
  - MAX_HP=200, HEADSHOT_MULTIPLIER=2.0
  - 30 武器 Damage 全部與 retune table 對齊（Wraith Scout 120, Hunter 172, Abyss 220, Fang Demon 76, Hailstorm 18 等）
  - LOOT 4-tier keys 都在
  - RARITY 1.00→1.90（vs 舊 3.00）
- **Runtime spawn**：9 NPCs (Patrol 120HP/18dmg, Armored 300/28, Elite 500/40)
- **Player HUD**：\"200 / 200\" 直接顯示
- **Code path** (script_grep)：Sniper headshot 分支 ✓ / 4-tier medkit handler ✓

### ⚠️ Deferred 到 human playtest
- Wraith Scout 240 headshot 實際擊殺
- 其他 Type 命中 Head 不加成
- 4-tier medkit 視覺顏色（NPC 死掉 drop 出來時）
- 200 HP vs Patrol 攻擊 drain rate
- NPC 帽子/兜帽 accessory hit edge case

理由：`execute_luau` 是 client context，無法直接觸發 server-side NPC 死亡 / weapon damage 等 server-validated path。Sniper headshot integration test 需要實際在 PvP 中用 Wraith 武器擊殺玩家。

## Sprint 9 候選（見 receipts/sprint-8b-200hp-rebalance.md §Next）
1. 護甲片系統 (workloads/11)
2. Channel 式補血
3. 全武器 headshot 1.5x evaluation
4. Demon 武器商店價格 vs nerf 對齊
5. 古代長火槍

🤖 Generated with [Claude Code](https://claude.com/claude-code)