### PR TITLE
docs(sprint-9): demon price realignment proposal + manual playtest checklist

### DIFF
--- a/proposals/demon-shop-price-realignment.md
+++ b/proposals/demon-shop-price-realignment.md
@@ -79,12 +79,12 @@ Sprint 8b (b) 公式收斂：
 
 **Pros**：
 - 不會讓老玩家（已存了 50K 想買 Demon）感受到通膨
-- 仍維持 Common→Demon ~57x 的價格 gap（從現在 117x 收斂）
+- Common→Demon avg 價差從 97.8x（舊世界 45000/460）收斂到 73.4x（新世界 33750/460），用 min/min 衡量則從 117x（35000/300）→ 87.5x（26250/300）— **付費 gap 仍明顯但不再誇張**
 - 保住「Demon = 最強」的視覺體感
 
 **Cons**：
-- Demon 仍比舊世界相對「貴」（每 DPS 17K vs 舊 15K，+13%）
-- 不完全解決 price-per-DPS 失衡
+- Demon 仍比舊世界相對「貴」：avg 33750 / DPS 1.9 = **17763 price per DPS unit vs 舊 15000，+18.4%**
+- 不完全解決 price-per-DPS 失衡（仍比 Common 460 高 39x）
 
 ### 選項 B：Pure proportional —— 嚴格按 DPS 倍率變化等比
 
@@ -189,7 +189,7 @@ Sprint 8b (b) 公式收斂：
 ## 7. 工程影響
 
 很小：
-- 改 `src/ReplicatedStorage/GameConfig.lua` 30 個 weapon Price 數值（25 個有變動）
+- 改 `src/ReplicatedStorage/GameConfig.lua` 30 個武器中的 **20 個** Price 值（Common 5 + Uncommon 5 = 10 把不變；Rare 5 + Epic 6 + Legendary 5 + Demon 4 = 20 把有變動）
 - ShopController UI 自動讀新值，不需改
 - 不影響 ShopService DataStore（因為買到的武器名稱不變，只是新買價格不同）
 
@@ -209,7 +209,7 @@ Sprint 8b (b) 公式收斂：
 ## 9. Sprint 9 implementation 計劃（如選 A）
 
 1. CEO 拍板選項 + 確認新 prices
-2. 改 GameConfig.lua 25 個 Price 值
+2. 改 GameConfig.lua **20 個** Price 值（Rare 5 + Epic 6 + Legendary 5 + Demon 4；Common/Uncommon 不動）
 3. Studio MCP playtest：開 ShopUI 確認新價格顯示
 4. 在 verification/sprint-8b-runtime-checks.lua 加 Price assertions（每把武器新價）
 5. 產出 receipts/sprint-9a-demon-price-realign.md

--- a/proposals/demon-shop-price-realignment.md
+++ b/proposals/demon-shop-price-realignment.md
@@ -1,0 +1,215 @@
+# Demon / Legendary 武器商店價格 realignment（Sprint 8b 後遺症）
+
+Date: 2026-05-04
+Author: claude-code
+Status: 📋 待 CEO 拍板（3 個選項，推薦 A）
+Driving:  Sprint 8b (b) 決議把 Demon DPS 從 3.0x baseline 收斂到 1.9x baseline (-37%)，但商店價格沒動。
+Source: `proposals/30-weapon-dps-retune.md` + `receipts/sprint-8b-200hp-rebalance.md`
+
+---
+
+## TL;DR
+
+(b) 決議讓 Demon 武器 DPS 直接 nerf 37%，但 35K–55K 子彈幣的商店價格還是 Sprint 8 設定 (依舊 3.0x DPS 假設)。**Demon 變相超貴**：花 55K 拿 1.9x DPS 等同舊世界花 55K 拿一個 1.9x 武器 — 但舊世界 1.9x 是 Epic 區段，Epic 平均 8.7K coins。
+
+CEO 拍板路線 (b) 雖然解了 P2W 問題，但留下「Demon 物有所值嗎？」的 open question。本文件給 3 個選項。
+
+---
+
+## 1. Background
+
+Sprint 8b (b) 公式收斂：
+
+| Rarity | 舊 DPS 倍率 | 新 DPS 倍率 | DPS 變化 |
+|---|---|---|---|
+| Common | 1.00x | 1.00x | 0% |
+| Uncommon | 1.25x | 1.15x | **-8%** |
+| Rare | 1.55x | 1.30x | **-16%** |
+| Epic | 1.95x | 1.50x | **-23%** |
+| Legendary | 2.40x | 1.70x | **-29%** |
+| Demon | 3.00x | 1.90x | **-37%** |
+
+商店價格（GameConfig.WEAPONS[*].Price）**未調整**，仍是 Sprint 8 原值。
+
+---
+
+## 2. Current price-per-DPS 失衡分析
+
+每 tier 平均價格 ÷ 該 tier DPS 倍率（= 玩家「每 1 個 DPS 單位要花多少 coin」）：
+
+| Rarity | 平均售價 | 舊 DPS 倍率 | **舊 price/DPS** | 新 DPS 倍率 | **新 price/DPS** | 失衡 % |
+|---|---|---|---|---|---|---|
+| Common | 460 | 1.00 | 460 | 1.00 | 460 | 0% |
+| Uncommon | 1500 | 1.25 | 1200 | 1.15 | **1304** | +9% |
+| Rare | 3680 | 1.55 | 2374 | 1.30 | **2831** | +19% |
+| Epic | 8767 | 1.95 | 4496 | 1.50 | **5845** | +30% |
+| Legendary | 20200 | 2.40 | 8417 | 1.70 | **11882** | +41% |
+| Demon | 45000 | 3.00 | 15000 | 1.90 | **23684** | **+58%** |
+
+**Demon 武器現在每單位 DPS 要花 23.7K coins**，相對舊世界 15K → **多付 58% 才得到同樣 DPS 等級**。
+
+老玩家用「Demon = 最強」直覺購買，玩 1 場後感受到「咦怎麼沒比 Legendary 強多少」會直接質疑商店價值。
+
+---
+
+## 3. 三個選項
+
+### 選項 A（推薦）：Tier-uniform haircut，保留「Demon 是 elite」感受
+
+每個 tier 套一個固定折扣，比例溫和：
+
+| Rarity | 現價 | 折扣 | 新價（範例） |
+|---|---|---|---|
+| Common | 300–650 | 0% | 不變 |
+| Uncommon | 1200–1800 | 0% | 不變 |
+| Rare | 3000–4500 | -5% | 2850–4275 |
+| Epic | 7500–9800 | -10% | 6750–8820 |
+| Legendary | 16000–25000 | -20% | 12800–20000 |
+| Demon | 35000–55000 | **-25%** | **26250–41250** |
+
+**邏輯**：DPS gap 收斂 37% 但商店「感覺」是 progression 而非純 DPS — 給 -25% 的折扣（較 -37% 保守），讓玩家不會覺得「Demon 變廉價」。
+
+**Demon 武器新價（B 選項對照）**：
+- Fang Demon: 35000 → **26250**
+- Phantom Hellfire: 42000 → **31500**
+- Wraith Abyss: 48000 → **36000**
+- Thunder Bloodmoon: 55000 → **41250**
+
+可進一步 round：26250 → 26000，31500 → 32000 等便於玩家心算。
+
+**Pros**：
+- 不會讓老玩家（已存了 50K 想買 Demon）感受到通膨
+- 仍維持 Common→Demon ~57x 的價格 gap（從現在 117x 收斂）
+- 保住「Demon = 最強」的視覺體感
+
+**Cons**：
+- Demon 仍比舊世界相對「貴」（每 DPS 17K vs 舊 15K，+13%）
+- 不完全解決 price-per-DPS 失衡
+
+### 選項 B：Pure proportional —— 嚴格按 DPS 倍率變化等比
+
+每 tier 的價格 × （新倍率 / 舊倍率）：
+
+| Rarity | 現價 (avg) | × ratio | 新價 (avg) |
+|---|---|---|---|
+| Common | 460 | × 1.00 | 460 |
+| Uncommon | 1500 | × 0.92 | 1380 |
+| Rare | 3680 | × 0.84 | 3091 |
+| Epic | 8767 | × 0.77 | 6750 |
+| Legendary | 20200 | × 0.71 | 14342 |
+| Demon | 45000 | × 0.63 | **28350** |
+
+**Pros**：完美 mathematical alignment，每 tier price-per-DPS 與舊世界相同
+**Cons**：Demon 從 45K 砍到 28K **-37%**，老玩家可能反彈；商店「elite tier」感變淡
+
+### 選項 C：Status quo（不動價格）
+
+接受「Demon 是 luxury rarity tier，價格反映稀有度而非純 DPS」。
+
+**Pros**：
+- 0 工程
+- 商店 progression 感維持
+- Demon 玩家「我付這麼多就是要爽」
+
+**Cons**：
+- Sprint 8b 的 P2W 收斂功夫沒完全傳導到玩家感受
+- Demon 玩家 DPS 體驗不如預期 → 可能差評
+- price-per-DPS 失衡 +58% 的 Demon 是商店設計風險
+
+---
+
+## 4. 推薦：選項 A
+
+理由：
+1. **Sprint 8b 動機是降 P2W，不是讓 Demon 廉價** — 選項 A 平衡兩者
+2. **商店 progression 是長期留存核心** — 選項 B 砍 Demon 37% 太傷商店設計
+3. **選項 C 沒有閉環 8b 的後遺症** — 玩家會問「為什麼 Demon DPS 變弱但價格沒變」
+
+選項 A 的 Demon -25% 折扣是**「承認 nerf 但維持 elite tier 形象」**的中間路線。
+
+---
+
+## 5. 完整新價格表（如選 A）
+
+```lua
+-- ===== Common (5) — 0% =====
+["Viper Mk1"]      Price=  300  -- unchanged
+["Viper SD"]       Price=  350  -- unchanged
+["Fang Scout"]     Price=  450  -- unchanged
+["Thunder Stub"]   Price=  550  -- unchanged
+["Thunder Cut"]    Price=  650  -- unchanged
+
+-- ===== Uncommon (5) — 0% =====
+["Stinger Mk2"]    Price= 1200  -- unchanged
+["Stinger Tac"]    Price= 1350  -- unchanged
+["Phantom Ranger"] Price= 1500  -- unchanged
+["Wraith Scout"]   Price= 1650  -- unchanged
+["Stinger Burst"]  Price= 1800  -- unchanged
+
+-- ===== Rare (5) — -5% =====
+["Reaver-X"]       Price= 2850  -- was 3000
+["Phantom Night"]  Price= 3150  -- was 3300
+["Thunder Guard"]  Price= 3400  -- was 3600
+["Wraith Hunter"]  Price= 3800  -- was 4000
+["Thunder Triple"] Price= 4275  -- was 4500
+
+-- ===== Epic (6) — -10% =====
+["Stinger Storm"]  Price= 6750  -- was 7500
+["Phantom Apex"]   Price= 7200  -- was 8000
+["Wraith Frost"]   Price= 7650  -- was 8500
+["Phantom Whisper"]Price= 8100  -- was 9000
+["Thunder Royal"]  Price= 8800  -- was 9800
+["Viper Left"]     Price= 8800  -- was 9800
+
+-- ===== Legendary (5) — -20% =====
+["Viper Aurum"]    Price=12800  -- was 16000
+["Phantom Finale"] Price=14400  -- was 18000
+["Wraith Apex"]    Price=16000  -- was 20000
+["Thunder Crown"]  Price=17600  -- was 22000
+["Hailstorm"]      Price=20000  -- was 25000
+
+-- ===== Demon (4) — -25% =====
+["Fang Demon"]     Price=26250  -- was 35000
+["Phantom Hellfire"]Price=31500 -- was 42000
+["Wraith Abyss"]   Price=36000  -- was 48000
+["Thunder Bloodmoon"]Price=41250 -- was 55000
+```
+
+---
+
+## 6. 影響的玩家 / 系統
+
+- **新玩家**：升級到 Rare/Epic/Legendary/Demon 更便宜 → 商店 funnel 更平滑（正向）
+- **既有玩家** (DataStore 有 coins)：他們存的 coins **價值上升**（同樣 35K 現在能買到舊 47K 等級的 Demon）→ 正向
+- **既有 Demon 持有者**：他們花 50K 買到的武器，現在新玩家花 36K 就買到 → **可能感受不公平**。需要溝通說明：(b) decision 是 server-wide rebalance，獎勵新玩家進入。
+- **Daily quest reward / match reward 不需動** — 這只是商店價格 realignment
+
+---
+
+## 7. 工程影響
+
+很小：
+- 改 `src/ReplicatedStorage/GameConfig.lua` 30 個 weapon Price 數值（25 個有變動）
+- ShopController UI 自動讀新值，不需改
+- 不影響 ShopService DataStore（因為買到的武器名稱不變，只是新買價格不同）
+
+工時 ~0.2 天（含 verification）。
+
+---
+
+## 8. CEO 拍板項目
+
+- [ ] **採選項 A / B / C**？（推薦 A）
+- [ ] **Demon 折扣比例**：A 預設 -25%，可微調 -20% ~ -30%
+- [ ] **既有 Demon 玩家補償**：要不要對 Sprint 8b 之前買 Demon 的玩家做一次性補貼？（建議不做 — 太工程；但要在 patch note 說明）
+- [ ] **是否本 sprint 一起做還是 Sprint 9 第一個工作項**？（推薦 Sprint 9 開頭）
+
+---
+
+## 9. Sprint 9 implementation 計劃（如選 A）
+
+1. CEO 拍板選項 + 確認新 prices
+2. 改 GameConfig.lua 25 個 Price 值
+3. Studio MCP playtest：開 ShopUI 確認新價格顯示
+4. 在 verification/sprint-8b-runtime-checks.lua 加 Price assertions（每把武器新價）
+5. 產出 receipts/sprint-9a-demon-price-realign.md

--- a/verification/sprint-8b-manual-checklist.md
+++ b/verification/sprint-8b-manual-checklist.md
@@ -22,7 +22,8 @@ Purpose: Close the 5 integration tests that `verification/sprint-8b-runtime-chec
 
 - [ ] **Open Studio** at the Final Strike place
 - [ ] **Press Play** — 進大廳
-- [ ] **F9 開 Output 視窗** — 等等要看 server 端的 `[damagePlayer]` log 與 NPCDamaged 數字
+- [ ] **F9 開 Output 視窗** — Test 4 要看 server 端的 `[damagePlayer]` log（玩家受傷會印；NPC 受傷**不會**印 console）
+- [ ] **左側 Explorer 視窗顯示** — Tests 1/2/5 要直接看 NPC model 的 HP attribute 變化驗證 dmg 數字（NPC 受傷無 console log，但有頭頂浮動傷害數字 + Explorer 即時 HP）
 
 ---
 
@@ -66,21 +67,25 @@ Purpose: Close the 5 integration tests that `verification/sprint-8b-runtime-chec
 - [ ] 確認手上拿的是 **Wraith Scout**（不是 Viper Mk1）
 - [ ] 找一隻 Patrol NPC（120 HP）站著沒動的目標
 
+> **如何觀察 NPC 受傷數字**：MatchManager FireWeapon → NPCDamaged event → HUDController 在 NPC 頭上 spawn 一個 floating BillboardGui 顯示傷害數字（不是 console print）。觀察方式：
+> - **方式 A（最直觀）**：射擊瞬間看 NPC 頭頂浮動的傷害數字
+> - **方式 B（精確）**：Studio Explorer → workspace → 點該 NPC model → Properties 旁的 Attributes 頁籤看 HP attribute 即時變化
+> - 注意：Server 端**沒有** print NPC 受傷的 console log（不像玩家受傷會印 `[damagePlayer]`）
+
 **Action A — body shot**:
 - [ ] 對 Patrol 的 Torso (UpperTorso) 開 1 槍
-- [ ] 觀察 Patrol HP attribute（可在 Studio Explorer 看 NPC model.HP，或看 NPCDamaged event 印出的 dmg）
 
 **Expected**:
-- [ ] Damage = **120**（NPC HP 120 → 0，秒殺；console 印 NPCDamaged 數字 = 120）
+- [ ] 浮動傷害數字顯示 **120**（或 Explorer NPC.HP 從 120 → 0，秒殺）
 
 **Action B — headshot**:
 - [ ] 等下一隻活的 Patrol（剛剛 body shot 一發秒殺，要找新的）
 - [ ] 對 Patrol 的 **Head** 部位開 1 槍
 
 **Expected**:
-- [ ] Damage = **240**（120 × HEADSHOT_MULTIPLIER 2.0；對 Patrol 120 HP 是 overkill，秒殺；NPCDamaged 印 240）
+- [ ] 浮動傷害數字顯示 **240**（120 × HEADSHOT_MULTIPLIER 2.0；對 Patrol 120 HP 是 overkill 秒殺；Explorer NPC.HP 從 120 → -120）
 
-**Pass criteria**：body 120 dmg / head 240 dmg 兩個數值都在 console 看到
+**Pass criteria**：body 120 dmg / head 240 dmg 兩個數值都看到（floating number 或 Explorer attribute）
 
 ---
 
@@ -92,8 +97,8 @@ Purpose: Close the 5 integration tests that `verification/sprint-8b-runtime-chec
 - [ ] 對 Patrol 的 **Head** 部位開 1 槍
 
 **Expected**:
-- [ ] Damage = **30**（不是 60）— Pistol Type 不該觸發 HEADSHOT_MULTIPLIER
-- [ ] Console NPCDamaged event 印 30，**NOT** 60
+- [ ] 浮動傷害數字 = **30**（不是 60）— Pistol Type 不該觸發 HEADSHOT_MULTIPLIER
+- [ ] Explorer 看 Patrol.HP 從 120 → 90（drop 30，不是 60）
 
 **Why this matters**: 確認 `MatchManager.lua` FireWeapon handler 的 `if config.Type == "Sniper" and isHeadshot` 條件嚴格只 Sniper 適用，沒有 leak 到其他 Type。
 
@@ -139,9 +144,12 @@ Purpose: Close the 5 integration tests that `verification/sprint-8b-runtime-chec
 - 12 hits × 1.0s = **約 12 秒**（含 spawn protection 後的時間）
 - Sprint 8b 之前是 100 HP / 10 dmg = 10 hits / 10 秒
 
+> 玩家受傷**有** server console log：每次中槍 console 印一行 `[damagePlayer] <你的名字> -18 (X->Y) by NPC`。Test 4 可以靠這個 log 計次／確認 dmg=18。
+
 **Pass criteria**：
 - [ ] 從第一發攻擊到死 ~12 秒（容差 ±2 秒）
 - [ ] HUD HP 條從 200 線性降到 0
+- [ ] Console 看到 12 行 `[damagePlayer] ... -18 ...` log
 - [ ] 死後切觀戰相機（spectator camera）
 
 ---
@@ -173,7 +181,7 @@ Purpose: Close the 5 integration tests that `verification/sprint-8b-runtime-chec
 **Expected**:
 - [ ] Damage = **120**（命中 "Hood" 或 "HoodFront"，不是 "Head"）
 
-**Pass criteria**：3 種 NPC 戴的 accessory 命中時 console NPCDamaged 都印 120，不是 240。如果**有任何一個** accessory 觸發 240 → 設計 bug，hitPart.Name 邏輯需要修。
+**Pass criteria**：3 種 NPC 戴的 accessory 命中時，浮動傷害數字（或 Explorer NPC.HP 變化）都顯示 **120**，不是 240。如果**有任何一個** accessory 觸發 240 → 設計 bug，hitPart.Name 邏輯需要修。
 
 ---
 

--- a/verification/sprint-8b-manual-checklist.md
+++ b/verification/sprint-8b-manual-checklist.md
@@ -10,29 +10,60 @@ Purpose: Close the 5 integration tests that `verification/sprint-8b-runtime-chec
 3. 任何 expected 不符記錄到 §"Issues found" 段
 4. 跑完更新 `receipts/sprint-8b-studio-verify.md` §"Deferred" 區塊狀態，並 commit 本 checklist 結果
 
-## Setup（共用，一次做完）
+## Setup — Two-phase playtest
+
+> ⚠️ **必讀**：`MatchManager.initPlayerData()` 在 match start 時 snapshot `playerData[player].Weapon`，之後 `FireWeapon` 拒絕任何 `weaponName ~= data.Weapon`。中途買武器或按 EquipPrimaryWeapon **不會改 server 的 data.Weapon**，要等下一場 match init 才生效。
+>
+> 因此 Tests 分 2 個 phase 跑：
+> - **Phase 1**（用 starter Viper Mk1）：Test 2 + Test 4
+> - **Phase 2**（restart match 用 Wraith Scout）：Test 1 + Test 3 + Test 5
+
+### 共同 setup（一次）
 
 - [ ] **Open Studio** at the Final Strike place
 - [ ] **Press Play** — 進大廳
-- [ ] **走到 StartMatchPad** 觸發比賽
-- [ ] **等到 PvE 階段**（HUD 顯示 "PVE" + 倒數 timer）
-- [ ] **HUD 確認 "200 / 200"** （最初 spawn）
-- [ ] **F9 開 Output 視窗** — 等等要看 server 端的 `[damagePlayer]` log 與 client 端的 `[Reward]` log
-
-> 起手只有 starter weapons（Viper Mk1 + Fang Scout）。Wraith Scout 1650 子彈幣，新玩家 0 coins → 需要先打幾個 NPC 賺。**或捷徑**：playtest 中跳過 lobby 經濟 → 在 Command Bar 跑：
-> ```lua
-> if _G.CurrencyService then _G.CurrencyService.addCoins(game.Players:GetPlayers()[1], 5000, nil) end
-> ```
-> 直接給 5K coins 夠買 Wraith Scout + 還有 medkit 餘裕。
+- [ ] **F9 開 Output 視窗** — 等等要看 server 端的 `[damagePlayer]` log 與 NPCDamaged 數字
 
 ---
 
-## Test 1: Wraith Scout body 120 / headshot 240（Sniper headshot 正面驗證）
+### Phase 1: 用 starter Viper Mk1 跑 Test 2 + Test 4
 
-**Setup**:
-- [ ] Open shop UI (B 鍵)
-- [ ] 買 Wraith Scout（1650 coins）並 set as primary
-- [ ] 等比賽 respawn / re-equip 拿到 Wraith Scout
+- [ ] 確認手上拿 **Viper Mk1**（player 預設 STARTER_WEAPONS[1]）
+- [ ] **走到 StartMatchPad** 觸發比賽
+- [ ] **等到 PvE 階段**，HUD "200 / 200"
+- [ ] **跑 Test 2**（Pistol head hit ≠ Sniper bonus）— 見 §Test 2
+- [ ] **跑 Test 4**（200 HP drain rate）— 見 §Test 4
+- [ ] Test 2 + 4 完成後，**讓自己被 NPC 殺死**（或等比賽結束）回大廳
+
+---
+
+### Phase 2: 大廳買 Wraith Scout，restart match 跑 Test 1 + 3 + 5
+
+- [ ] 回到大廳（match end → lobby teleport）
+- [ ] **Command Bar 跑 coin grant**（bypass MatchTotal cap，必須用 addDailyReward 而非 addCoins）：
+  ```lua
+  -- addDailyReward 跳過 GameConfig.ECONOMY.MatchCaps.MatchTotal = 1500 限制
+  -- 用 addCoins(_, _, nil) 會只發 1500 coins，買不起 1650 的 Wraith Scout
+  if _G.CurrencyService then
+      _G.CurrencyService.addDailyReward(game.Players:GetPlayers()[1], 5000, "playtest setup")
+  end
+  ```
+  HUD 子彈幣顯示應跳到 **5000+**
+- [ ] **B 鍵開 Shop UI**
+- [ ] **買 Wraith Scout**（1650 coins）
+- [ ] **設 Wraith Scout 為 primary**（shop UI 按 Equip）→ 觸發 PrimaryWeaponUpdate
+- [ ] **走到 StartMatchPad 重新觸發比賽** — `initPlayerData` 會 snapshot Wraith Scout 為 `data.Weapon`
+- [ ] **等到 PvE 階段**，**確認手上拿 Wraith Scout**（不是 Viper Mk1）
+- [ ] **跑 Test 1**（Wraith body / head）— 見 §Test 1
+- [ ] **跑 Test 3**（NPC drop visual，殺 Elite）— 見 §Test 3
+- [ ] **跑 Test 5**（NPC accessory edge）— 見 §Test 5
+
+---
+
+## Test 1: Wraith Scout body 120 / headshot 240（Sniper headshot 正面驗證） — Phase 2
+
+**Setup**: 已在 Phase 2 setup 買好 Wraith Scout、set primary、re-start match → init snapshot 用 Wraith Scout。
+- [ ] 確認手上拿的是 **Wraith Scout**（不是 Viper Mk1）
 - [ ] 找一隻 Patrol NPC（120 HP）站著沒動的目標
 
 **Action A — body shot**:
@@ -43,7 +74,7 @@ Purpose: Close the 5 integration tests that `verification/sprint-8b-runtime-chec
 - [ ] Damage = **120**（NPC HP 120 → 0，秒殺；console 印 NPCDamaged 數字 = 120）
 
 **Action B — headshot**:
-- [ ] Spawn 新一場比賽（或等下一波 NPC）
+- [ ] 等下一隻活的 Patrol（剛剛 body shot 一發秒殺，要找新的）
 - [ ] 對 Patrol 的 **Head** 部位開 1 槍
 
 **Expected**:
@@ -53,9 +84,9 @@ Purpose: Close the 5 integration tests that `verification/sprint-8b-runtime-chec
 
 ---
 
-## Test 2: Pistol Head hit ≠ Sniper bonus（headshot 負面驗證）
+## Test 2: Pistol Head hit ≠ Sniper bonus（headshot 負面驗證） — Phase 1
 
-**Setup**：拿 starter Viper Mk1（30 dmg, Type=Pistol）
+**Setup**：Phase 1，玩家手上是 starter **Viper Mk1**（30 dmg, Type=Pistol）— 這是 init 預設 primary，data.Weapon=Viper Mk1，FireWeapon 接受。
 
 **Action**:
 - [ ] 對 Patrol 的 **Head** 部位開 1 槍
@@ -70,9 +101,9 @@ Purpose: Close the 5 integration tests that `verification/sprint-8b-runtime-chec
 
 ---
 
-## Test 3: 4-tier medkit visual color from NPC drop
+## Test 3: 4-tier medkit visual color from NPC drop — Phase 2
 
-**Setup**: 站在 Elite NPC 附近（500 HP、紅色發光、可能戴兜帽）
+**Setup**: Phase 2 中（Wraith Scout 為 primary）。站在 Elite NPC 附近（500 HP、紅色發光、可能戴兜帽）
 
 **Action**:
 - [ ] 用 Wraith Scout 連續打 Elite 直到死（500 HP / 120 body = 5 發 body，或 1 爆頭 + 2 body）
@@ -95,9 +126,9 @@ Purpose: Close the 5 integration tests that `verification/sprint-8b-runtime-chec
 
 ---
 
-## Test 4: 200 HP vs Patrol attack drain rate（NPC ×2 damage 驗證）
+## Test 4: 200 HP vs Patrol attack drain rate（NPC ×2 damage 驗證） — Phase 1
 
-**Setup**:
+**Setup**: Phase 1（Viper Mk1 starter）— Test 4 是純被動觀察 drain rate，武器無關。Phase 2 也可以但 Phase 1 順便做最有效率。
 - [ ] 走到一隻 Patrol NPC 攻擊範圍內（AttackRange = 6）
 - [ ] **不要躲也不要還手**，站樁讓 Patrol 攻擊
 - [ ] 計時器（手機 stopwatch 或 console 看時間）
@@ -115,9 +146,9 @@ Purpose: Close the 5 integration tests that `verification/sprint-8b-runtime-chec
 
 ---
 
-## Test 5: NPC accessory（cap/helmet/hood）head-hit edge case
+## Test 5: NPC accessory（cap/helmet/hood）head-hit edge case — Phase 2
 
-**Setup**: 拿 Wraith Scout
+**Setup**: Phase 2，玩家拿 Wraith Scout
 
 **Why test**：D1 設計只 hitPart.Name == "Head" 觸發爆頭。但 NPC 戴的 hat/cap/helmet/hood 是獨立的 Part 掛在 Head 上（NPCSystem.dressNPC），它們的 Name 不是 "Head" 所以不該觸發爆頭加成 — 視覺上「子彈打到頭盔被擋」。
 

--- a/verification/sprint-8b-manual-checklist.md
+++ b/verification/sprint-8b-manual-checklist.md
@@ -1,0 +1,164 @@
+# Sprint 8b Manual Playtest Checklist — 5 Deferred Integration Tests
+
+Date: 2026-05-04
+Purpose: Close the 5 integration tests that `verification/sprint-8b-runtime-checks.lua` could not auto-verify (執行 luau 在 client context 跑不了 server-side state mutation；參見 `receipts/sprint-8b-studio-verify.md` §"Deferred"). 一次 human playtest，~10 分鐘。
+
+## How to use
+
+1. 開 Final Strike `.rbxl`、按 Play
+2. 走完每個 §X 步驟，在 `[ ]` 打勾
+3. 任何 expected 不符記錄到 §"Issues found" 段
+4. 跑完更新 `receipts/sprint-8b-studio-verify.md` §"Deferred" 區塊狀態，並 commit 本 checklist 結果
+
+## Setup（共用，一次做完）
+
+- [ ] **Open Studio** at the Final Strike place
+- [ ] **Press Play** — 進大廳
+- [ ] **走到 StartMatchPad** 觸發比賽
+- [ ] **等到 PvE 階段**（HUD 顯示 "PVE" + 倒數 timer）
+- [ ] **HUD 確認 "200 / 200"** （最初 spawn）
+- [ ] **F9 開 Output 視窗** — 等等要看 server 端的 `[damagePlayer]` log 與 client 端的 `[Reward]` log
+
+> 起手只有 starter weapons（Viper Mk1 + Fang Scout）。Wraith Scout 1650 子彈幣，新玩家 0 coins → 需要先打幾個 NPC 賺。**或捷徑**：playtest 中跳過 lobby 經濟 → 在 Command Bar 跑：
+> ```lua
+> if _G.CurrencyService then _G.CurrencyService.addCoins(game.Players:GetPlayers()[1], 5000, nil) end
+> ```
+> 直接給 5K coins 夠買 Wraith Scout + 還有 medkit 餘裕。
+
+---
+
+## Test 1: Wraith Scout body 120 / headshot 240（Sniper headshot 正面驗證）
+
+**Setup**:
+- [ ] Open shop UI (B 鍵)
+- [ ] 買 Wraith Scout（1650 coins）並 set as primary
+- [ ] 等比賽 respawn / re-equip 拿到 Wraith Scout
+- [ ] 找一隻 Patrol NPC（120 HP）站著沒動的目標
+
+**Action A — body shot**:
+- [ ] 對 Patrol 的 Torso (UpperTorso) 開 1 槍
+- [ ] 觀察 Patrol HP attribute（可在 Studio Explorer 看 NPC model.HP，或看 NPCDamaged event 印出的 dmg）
+
+**Expected**:
+- [ ] Damage = **120**（NPC HP 120 → 0，秒殺；console 印 NPCDamaged 數字 = 120）
+
+**Action B — headshot**:
+- [ ] Spawn 新一場比賽（或等下一波 NPC）
+- [ ] 對 Patrol 的 **Head** 部位開 1 槍
+
+**Expected**:
+- [ ] Damage = **240**（120 × HEADSHOT_MULTIPLIER 2.0；對 Patrol 120 HP 是 overkill，秒殺；NPCDamaged 印 240）
+
+**Pass criteria**：body 120 dmg / head 240 dmg 兩個數值都在 console 看到
+
+---
+
+## Test 2: Pistol Head hit ≠ Sniper bonus（headshot 負面驗證）
+
+**Setup**：拿 starter Viper Mk1（30 dmg, Type=Pistol）
+
+**Action**:
+- [ ] 對 Patrol 的 **Head** 部位開 1 槍
+
+**Expected**:
+- [ ] Damage = **30**（不是 60）— Pistol Type 不該觸發 HEADSHOT_MULTIPLIER
+- [ ] Console NPCDamaged event 印 30，**NOT** 60
+
+**Why this matters**: 確認 `MatchManager.lua` FireWeapon handler 的 `if config.Type == "Sniper" and isHeadshot` 條件嚴格只 Sniper 適用，沒有 leak 到其他 Type。
+
+**Optional 進階**: 拿 Phantom Ranger（Rifle, 19 dmg）對 head — 應該是 19 dmg 不是 38。
+
+---
+
+## Test 3: 4-tier medkit visual color from NPC drop
+
+**Setup**: 站在 Elite NPC 附近（500 HP、紅色發光、可能戴兜帽）
+
+**Action**:
+- [ ] 用 Wraith Scout 連續打 Elite 直到死（500 HP / 120 body = 5 發 body，或 1 爆頭 + 2 body）
+- [ ] 看 NPC 死亡後 spawn 的 loot pickup 球體顏色
+
+**Expected**（per dropLoot rolls）:
+- 50% 機率出 **MedkitLarge**（深綠色 RGB 20/200/80）
+- 5% 機率出 **MedkitFull**（米白色 RGB 255/255/200）— 要多打幾次才看得到
+- 40% 機率 Ammo（黃 255/200/50）
+- 50% 機率 Coin（金 255/215/0）
+
+各 lootType 是獨立 roll，所以一隻 Elite 可能出 0-3 個 pickups。
+
+**Pass criteria**：
+- [ ] 至少看到一次 MedkitLarge 深綠球（可能 1-2 隻 Elite 死後就出）
+- [ ] 試運氣看到 MedkitFull 米白球（10-20 隻 Elite 死後機率高）
+- [ ] 撿起 MedkitLarge → HUD HP +150（如果你受傷的話）
+
+進階：殺 Patrol NPC → 看 MedkitSmall (淺綠 120/255/150)；殺 Armored → 看 Medkit (標準綠 50/255/100)。
+
+---
+
+## Test 4: 200 HP vs Patrol attack drain rate（NPC ×2 damage 驗證）
+
+**Setup**:
+- [ ] 走到一隻 Patrol NPC 攻擊範圍內（AttackRange = 6）
+- [ ] **不要躲也不要還手**，站樁讓 Patrol 攻擊
+- [ ] 計時器（手機 stopwatch 或 console 看時間）
+
+**Expected**:
+- Patrol Damage = 18 / AttackRate = 1 秒
+- 200 HP / 18 dmg = 11.11 → 12 hits 死
+- 12 hits × 1.0s = **約 12 秒**（含 spawn protection 後的時間）
+- Sprint 8b 之前是 100 HP / 10 dmg = 10 hits / 10 秒
+
+**Pass criteria**：
+- [ ] 從第一發攻擊到死 ~12 秒（容差 ±2 秒）
+- [ ] HUD HP 條從 200 線性降到 0
+- [ ] 死後切觀戰相機（spectator camera）
+
+---
+
+## Test 5: NPC accessory（cap/helmet/hood）head-hit edge case
+
+**Setup**: 拿 Wraith Scout
+
+**Why test**：D1 設計只 hitPart.Name == "Head" 觸發爆頭。但 NPC 戴的 hat/cap/helmet/hood 是獨立的 Part 掛在 Head 上（NPCSystem.dressNPC），它們的 Name 不是 "Head" 所以不該觸發爆頭加成 — 視覺上「子彈打到頭盔被擋」。
+
+**Action A — Patrol Cap (Security cap)**:
+- [ ] 找 Patrol，瞄準它頭頂的小帽子（不是臉部）
+- [ ] 開 1 槍
+
+**Expected**:
+- [ ] Damage = **120**（不是 240）— 命中 "Cap" Part 而非 "Head"，不算爆頭
+
+**Action B — Armored Helmet**:
+- [ ] 找 Armored，瞄準它的戰術頭盔（覆蓋整個頭部）
+- [ ] 開 1 槍
+
+**Expected**:
+- [ ] Damage = **120**（命中 "Helmet" 或 "HelmetVisor"，不是 "Head"）
+
+**Action C — Elite Hood**:
+- [ ] 找 Elite，瞄準兜帽（包覆頭部）
+- [ ] 開 1 槍
+
+**Expected**:
+- [ ] Damage = **120**（命中 "Hood" 或 "HoodFront"，不是 "Head"）
+
+**Pass criteria**：3 種 NPC 戴的 accessory 命中時 console NPCDamaged 都印 120，不是 240。如果**有任何一個** accessory 觸發 240 → 設計 bug，hitPart.Name 邏輯需要修。
+
+---
+
+## Issues found during playtest
+
+> 玩家寫進這段，每條附 step、expected、actual、可能原因。
+
+-
+
+---
+
+## Post-playtest steps
+
+- [ ] 把 Test 1-5 的勾與 Issues found 留在這份 checklist 裡
+- [ ] Commit 這份 checklist 已勾選版本到 repo
+- [ ] 更新 `receipts/sprint-8b-studio-verify.md` §"⚠️ Interactive integration tests deferred" 表格 — 把 5 個 deferred 項目改成 ✅ verified manual playtest YYYY-MM-DD
+- [ ] 如有 issues found → 開 GitHub issue 或新 PR fix
+
+如果 5 項 Pass，Sprint 8b 才能宣告 production-ready。


### PR DESCRIPTION
## Summary

Sprint 9 開頭兩個並行 artifacts。**只有 docs，沒 runtime 程式碼變更**。

### Item #1: Demon shop price realignment proposal
- `proposals/demon-shop-price-realignment.md`
- 解決 Sprint 8b 的 P2W 後遺症：(b) 決議讓 Demon DPS 從 3.0x → 1.9x（-37%），但商店價格還停在 Sprint 8 設定 (35K-55K)
- Price-per-DPS 失衡分析：Demon 現在每 DPS 單位要花 23.7K coins，比舊世界 +58%
- 3 個選項給 CEO 拍板：A (推薦 -25% Demon)、B (純比例 -37%)、C (不動)
- 完整新價格表（option A）+ 影響評估 + 工程計劃
- Option A 實際數據：Demon avg/avg gap 從 97.8x → **73.4x**（min/min 117x → 87.5x）；Demon price/DPS = 17763 (+18.4% vs 舊 15000)；20 個 weapon Price 改動

### Item #6: Sprint 8b manual playtest checklist
- `verification/sprint-8b-manual-checklist.md`
- 把 receipts/sprint-8b-studio-verify.md 的 5 個 deferred items 寫成具體 playtest 步驟
- **2-phase 結構**：Phase 1 (default Viper Mk1) Test 2/4；Phase 2 (lobby 買 Wraith → restart match) Test 1/3/5
- Setup 用 `addDailyReward` bypass MatchTotal cap 來授予 5K coins（addCoins 被 1500 cap 擋）
- 每個 NPC-damage Test 改用浮動傷害數字 + Explorer NPC.HP attribute 觀察（NPCDamaged 不會 print 到 console）
- ~10 分鐘 human playtest 收斂 Sprint 8b production-ready gap

## CEO 拍板項目（Item #1）

- [ ] 選 **A / B / C**？（推薦 A）
- [ ] Demon 折扣比例：A 預設 -25%，可微調 -20% ~ -30%
- [ ] 既有 Demon 玩家補償？（建議 patch note 說明，不一次性補貼）
- [ ] 本 sprint 一起做還是 Sprint 9 第二個工作項？

## Test plan

- [ ] CEO 審閱 demon price proposal §3 三選項
- [ ] CEO/玩家 跑 manual playtest checklist 一次（2 phases）
- [ ] 5 deferred integration tests pass → 更新 receipts/sprint-8b-studio-verify.md 為 ✅ production-ready
- [ ] 拍板選項 → 開 sprint-9-impl PR 改 GameConfig **20 個 Price 值**（Common+Uncommon 不動，Rare/Epic/Legendary/Demon 共 20 把）

## Stack 狀態

main 上目前所有 Sprint 8/8a/8b PR 都已 merge：
- PR #23: 200 HP rebalance design (merged)
- PR #25: Sprint 8a hygiene + 30-weapon retune doc (merged)
- PR #26: Sprint 8b implementation (merged)
- PR #27: Sprint 8b verification artifact (merged)
- **PR (this)**: Sprint 9 prep — Demon price + manual checklist

🤖 Generated with [Claude Code](https://claude.com/claude-code)