### PR TITLE
feat(sprint-9a): demon/legendary shop price realignment (Option A)

### DIFF
--- a/receipts/sprint-8b-studio-verify.md
+++ b/receipts/sprint-8b-studio-verify.md
@@ -126,27 +126,29 @@ These need a human play session — recommend doing 1 manual playtest before ann
 
 ### Check counts（依執行 context）
 
-Script 有 **62 個 static checks** + 條件式 runtime checks。實際 pass 數隨呼叫時的遊戲狀態變動：
+> ⚠️ **2026-05-04 update**：Sprint 9a 在這個 script 加了 30 個 Price assertions（Sprint 9a price realignment 的 verification — 見 `receipts/sprint-9a-demon-price-realign.md`）。下方 count table 已更新為 **post-Sprint-9a current state**。
+
+Script 有 **92 個 static checks** + 條件式 runtime checks。實際 pass 數隨呼叫時的遊戲狀態變動：
 
 | Context | Static | Runtime NPC | HUD | **Total** |
 |---|---|---|---|---|
-| Lobby（無 NPC、HUD 已建）| 62 | 0 | 1 | **63** |
-| PvE（NPC + HUD 都有）| 62 | 6 | 1 | **69** |
-| Server-only / 沒 LocalPlayer | 62 | 0 or 6 | 0 | **62 / 68** |
+| Lobby（無 NPC、HUD 已建）| 92 | 0 | 1 | **93** |
+| PvE（NPC + HUD 都有）| 92 | 6 | 1 | **99** |
+| Server-only / 沒 LocalPlayer | 92 | 0 or 6 | 0 | **92 / 98** |
 
-Static 62 = base (2) + Rarity (6) + Weapons Damage (30) + Sniper Type (5) + ENEMIES HP/Damage (6) + LootTable presence (4) + Weapon-drop-removed (3) + LOOT 6-entry (6).
+Static 92 = base (2) + Rarity (6) + Weapons Damage (30) + Sniper Type (5) + ENEMIES HP/Damage (6) + LootTable presence (4) + Weapon-drop-removed (3) + LOOT 6-entry (6) + **Sprint 9a Weapons Price (30)**.
 
 Skipped sections print `[VERIFY SKIP]` lines explaining why（無 NPC / 無 HUD / server-only），不計入 fail。
 
-### Last self-test result（2026-05-04, MCP execute_luau on `最後一擊` instance, PvE phase with HUD）
+### Self-test history
 
-```
-{ passed = 69, failed = 0, failures = [], hasNpcs = true, hadHud = true }
-```
+**Sprint 8b merge (2026-05-04, pre-Sprint-9a)**: `{ passed = 69, failed = 0, failures = [], hasNpcs = true, hadHud = true }` — 62 static + 6 runtime NPC + 1 HUD，完整覆蓋當時設計合約。
 
-69/69 通過 = 62 static + 6 runtime NPC + 1 HUD = 完整覆蓋。
+**Sprint 9a merge (2026-05-04, post-Sprint-9a)**: `{ passed = 99, failed = 0, failures = [], hasNpcs = true, hadHud = true }` — 92 static + 6 runtime NPC + 1 HUD，完整覆蓋 Sprint 8b + 9a 合約。
 
-Screenshot at `sprint_8b_pve_phase` (MCP session-bound) 仍可作為視覺輔助，但不再是審計主憑據 — 以 `verification/sprint-8b-runtime-checks.lua` 的 structured return 為準。
+> 兩次都是同一個 script 跑出來的；69→99 的 +30 差距完全來自 Sprint 9a 加入的 Price assertions。CEO 拍板 Option A 後 30 個 Price 全部對齊 = 0 fail。
+
+Screenshot at `sprint_8b_pve_phase` (MCP session-bound) 仍可作為視覺輔助，但不再是審計主憑據 — 以 `verification/sprint-8b-runtime-checks.lua` 的 structured return 為準。腳本 header docstring 永遠保有當前 count breakdown。
 
 ## Next
 

--- a/receipts/sprint-9a-demon-price-realign.md
+++ b/receipts/sprint-9a-demon-price-realign.md
@@ -1,0 +1,123 @@
+# Sprint 9a Receipt — Demon / Legendary 武器商店價格 realignment (Option A)
+
+Date: 2026-05-04
+CEO Decision: 2026-05-04 — 選 Option A、Demon -25%
+Source: `proposals/demon-shop-price-realignment.md` §3 + §5
+
+## Status: ✅ IMPLEMENTED + VERIFIED
+
+20 個 weapon Price 已套到 main + Studio。Verification script 加 30 個 Price assertions 全部 pass。
+
+## Tier discount table（已套用）
+
+| Rarity | 折扣 | 影響 weapons |
+|---|---|---|
+| Common | 0% | 5 把（不變）|
+| Uncommon | 0% | 5 把（不變）|
+| Rare | **-5%** | 5 把（Reaver-X, Phantom Night, Thunder Guard, Wraith Hunter, Thunder Triple）|
+| Epic | **-10%** | 6 把（Stinger Storm, Phantom Apex, Wraith Frost, Phantom Whisper, Thunder Royal, Viper Left）|
+| Legendary | **-20%** | 5 把（Viper Aurum, Phantom Finale, Wraith Apex, Thunder Crown, Hailstorm）|
+| Demon | **-25%** | 4 把（Fang Demon, Phantom Hellfire, Wraith Abyss, Thunder Bloodmoon）|
+
+## Per-weapon Price changes（20 個）
+
+### Rare (5 — -5%)
+
+| 武器 | 舊價 | 新價 | 算式 |
+|---|---|---|---|
+| Reaver-X | 3000 | **2850** | 3000 × 0.95 = 2850 |
+| Phantom Night | 3300 | **3150** | 3300 × 0.95 = 3135 → 3150（rounded） |
+| Thunder Guard | 3600 | **3400** | 3600 × 0.95 = 3420 → 3400（rounded） |
+| Wraith Hunter | 4000 | **3800** | 4000 × 0.95 = 3800 |
+| Thunder Triple | 4500 | **4275** | 4500 × 0.95 = 4275 |
+
+### Epic (6 — -10%)
+
+| 武器 | 舊價 | 新價 |
+|---|---|---|
+| Stinger Storm | 7500 | **6750** |
+| Phantom Apex | 8000 | **7200** |
+| Wraith Frost | 8500 | **7650** |
+| Phantom Whisper | 9000 | **8100** |
+| Thunder Royal | 9800 | **8800**（rounded down from 8820）|
+| Viper Left | 9800 | **8800**（rounded down from 8820）|
+
+### Legendary (5 — -20%)
+
+| 武器 | 舊價 | 新價 |
+|---|---|---|
+| Viper Aurum | 16000 | **12800** |
+| Phantom Finale | 18000 | **14400** |
+| Wraith Apex | 20000 | **16000** |
+| Thunder Crown | 22000 | **17600** |
+| Hailstorm | 25000 | **20000** |
+
+### Demon (4 — -25%)
+
+| 武器 | 舊價 | 新價 |
+|---|---|---|
+| Fang Demon | 35000 | **26250** |
+| Phantom Hellfire | 42000 | **31500** |
+| Wraith Abyss | 48000 | **36000** |
+| Thunder Bloodmoon | 55000 | **41250** |
+
+## Test Evidence
+
+### Static config verification
+
+跑 `verification/sprint-8b-runtime-checks.lua` 的新增 §3.5 Price assertions（30 weapons）:
+
+```
+{ passed = 30, failed = 0, failures = [] }
+```
+
+Verification script self-test on running Studio (post-realignment): 30/30 prices match expected.
+
+### 工程改動
+
+```
+src/ReplicatedStorage/GameConfig.lua             — 20 weapon Price 改動 + 註解 block 新增
+verification/sprint-8b-runtime-checks.lua        — 新增 §3.5 priceExpect table + 30 個 Price check
+receipts/sprint-9a-demon-price-realign.md        — 本 receipt
+```
+
+不影響：
+- ShopController UI（自動讀新 Price）
+- ShopService DataStore（武器名稱不變，只是新買價格不同）
+- 已擁有武器的玩家（已買的不會被收回，coin 也不退）
+
+## DPS-per-coin 結果驗證（Option A 預期）
+
+選項 A 的目標是收斂 Demon price-per-DPS（之前 +58% vs 舊世界）：
+
+| Rarity | 平均售價 | 新 DPS 倍率 | **新 price/DPS** | 改前 | 改後變動 |
+|---|---|---|---|---|---|
+| Common | 460 | 1.00 | 460 | 460 | 0% |
+| Uncommon | 1500 | 1.15 | 1304 | 1304 | 0% |
+| Rare | 3495 | 1.30 | 2688 | 2831 | -5% |
+| Epic | 7883 | 1.50 | 5256 | 5845 | -10% |
+| Legendary | 16160 | 1.70 | 9506 | 11882 | -20% |
+| Demon | 33750 | 1.90 | **17763** | 23684 | **-25%** |
+
+Demon price/DPS 從 23684（pre-realignment）→ 17763（Option A），**-25%**，符合期望。
+仍比舊世界 15000 高 +18%（接受 trade-off：商店 progression > 完美 DPS 對齊）。
+
+## CEO 拍板溯源
+
+CEO 在 2026-05-04 訊息：「demon price（"選 A，Demon -25%"）」→ 對應 proposal §3 Option A + §5 完整價格表。所有改動嚴格依照 §5 範例價格表。
+
+## Lessons Learned
+
+- **`gh pr edit --body` 可以一次更新整份 PR description** — 用 HEREDOC 餵入。對 review pass 之後 stale numbers 修正是 must-have（PR #28 review 抓到 PR body 與文件不同步，正是這個用法）
+- **Studio multi_edit 一次 21 edits 沒問題** — 大批量精準替換比逐個 Edit 快多了，前提是每個 old_string 在檔內 unique
+- **驗證 script 加 Price assertions 是 worth it** — 加 30 個 check 一次寫，未來任何 GameConfig.Price drift（誤改、merge conflict）都會被抓
+- **Receipt 用「per-tier table」+「per-weapon table」雙層結構** — CEO 看 tier 表確認決策落地，工程 review 對 weapon 表逐個 verify 算式
+
+## Next: Sprint 9 候選（仍待 CEO 拍板）
+
+從 `receipts/sprint-8b-200hp-rebalance.md` §Next 取仍未做的：
+1. **Manual playtest checklist 跑一輪** — 5 deferred items 收尾 Sprint 8b production-ready（不阻塞，但建議盡快做完）
+2. **護甲片系統**（workloads/11，需 CEO Q4 拍板）
+3. **Channel 式補血**（需 CEO Q3 拍板）
+4. **古代長火槍**（需 CEO 重新拍板，原 Q5 deferred Sprint 10+）
+5. **全武器 headshot 1.5x evaluation**（需 production data，玩家上線後才有）

--- a/src/ReplicatedStorage/GameConfig.lua
+++ b/src/ReplicatedStorage/GameConfig.lua
@@ -47,6 +47,11 @@ GameConfig.RARITY = {
 -- Type baselines: Pistol 75 / SMG 110 / Rifle 110 / Shotgun 99 / Sniper 110 / Knife 80.
 -- Hailstorm Minigun: option B (Damage 18 unchanged, SpinUp is the trade-off).
 -- See proposals/30-weapon-dps-retune.md for full table + per-weapon TTK.
+--
+-- Sprint 9 (Option A) — shop price realignment per CEO 2026-05-04 decision:
+-- tier-graduated discount aligning coin cost with post-(b) DPS reality.
+--   Common 0% / Uncommon 0% / Rare -5% / Epic -10% / Legendary -20% / Demon -25%
+-- See proposals/demon-shop-price-realignment.md.
 GameConfig.WEAPONS = {
 	-- ===== Common (5) — 1.00x DPS =====
 	["Viper Mk1"]      = { Type="Pistol",  Rarity="Common",    Price=  300, Damage= 30, FireRate=0.40, MagSize=12, ReloadTime=1.5, Range=200, Spread=0.020, Auto=false },  -- was 25
@@ -63,32 +68,32 @@ GameConfig.WEAPONS = {
 	["Stinger Burst"]  = { Type="SMG",     Rarity="Uncommon",  Price= 1800, Damage=  9, FireRate=0.07,  MagSize=32, ReloadTime=2.0, Range=140, Spread=0.045, Auto=true },  -- was 14
 
 	-- ===== Rare (5) — 1.30x DPS =====
-	["Reaver-X"]       = { Type="Rifle",   Rarity="Rare",      Price= 3000, Damage= 20, FireRate=0.14,  MagSize=30, ReloadTime=2.4, Range=320, Spread=0.020, Auto=true },  -- was 42
-	["Phantom Night"]  = { Type="Rifle",   Rarity="Rare",      Price= 3300, Damage= 17, FireRate=0.12,  MagSize=30, ReloadTime=2.3, Range=320, Spread=0.014, Auto=true },  -- was 38
-	["Thunder Guard"]  = { Type="Shotgun", Rarity="Rare",      Price= 3600, Damage= 12, Pellets=8, FireRate=0.75, MagSize=6, ReloadTime=2.7, Range=55, Spread=0.10, Auto=false },  -- was 14
-	["Wraith Hunter"]  = { Type="Sniper",  Rarity="Rare",      Price= 4000, Damage=172, FireRate=1.20,  MagSize=6,  ReloadTime=3.2, Range=480, Spread=0.006, Auto=false }, -- was 110
-	["Thunder Triple"] = { Type="Shotgun", Rarity="Rare",      Price= 4500, Damage= 11, Pellets=9, FireRate=0.80, MagSize=3, ReloadTime=3.5, Range=50, Spread=0.13, Auto=false },  -- was 15
+	["Reaver-X"]       = { Type="Rifle",   Rarity="Rare",      Price= 2850, Damage= 20, FireRate=0.14,  MagSize=30, ReloadTime=2.4, Range=320, Spread=0.020, Auto=true },  -- price was 3000 (-5%)
+	["Phantom Night"]  = { Type="Rifle",   Rarity="Rare",      Price= 3150, Damage= 17, FireRate=0.12,  MagSize=30, ReloadTime=2.3, Range=320, Spread=0.014, Auto=true },  -- price was 3300 (-5% rounded)
+	["Thunder Guard"]  = { Type="Shotgun", Rarity="Rare",      Price= 3400, Damage= 12, Pellets=8, FireRate=0.75, MagSize=6, ReloadTime=2.7, Range=55, Spread=0.10, Auto=false },  -- price was 3600 (-5% rounded)
+	["Wraith Hunter"]  = { Type="Sniper",  Rarity="Rare",      Price= 3800, Damage=172, FireRate=1.20,  MagSize=6,  ReloadTime=3.2, Range=480, Spread=0.006, Auto=false }, -- price was 4000 (-5%)
+	["Thunder Triple"] = { Type="Shotgun", Rarity="Rare",      Price= 4275, Damage= 11, Pellets=9, FireRate=0.80, MagSize=3, ReloadTime=3.5, Range=50, Spread=0.13, Auto=false },  -- price was 4500 (-5%)
 
 	-- ===== Epic (6) — 1.50x DPS =====
-	["Stinger Storm"]  = { Type="SMG",     Rarity="Epic",      Price= 7500, Damage= 12, FireRate=0.075, MagSize=35, ReloadTime=1.9, Range=170, Spread=0.035, Auto=true },  -- was 22
-	["Phantom Apex"]   = { Type="Rifle",   Rarity="Epic",      Price= 8000, Damage= 21, FireRate=0.13,  MagSize=30, ReloadTime=2.2, Range=340, Spread=0.013, Auto=true },  -- was 50
-	["Wraith Frost"]   = { Type="Sniper",  Rarity="Epic",      Price= 8500, Damage=190, FireRate=1.15,  MagSize=6,  ReloadTime=3.0, Range=520, Spread=0.005, Auto=false }, -- was 140
-	["Phantom Whisper"]= { Type="Rifle",   Rarity="Epic",      Price= 9000, Damage= 25, FireRate=0.15,  MagSize=24, ReloadTime=2.4, Range=360, Spread=0.011, Auto=true, Silent=true },  -- was 55 (Silent unchanged)
-	["Thunder Royal"]  = { Type="Shotgun", Rarity="Epic",      Price= 9800, Damage= 13, Pellets=8, FireRate=0.70, MagSize=6, ReloadTime=2.6, Range=60, Spread=0.09, Auto=false },  -- was 18
-	["Viper Left"]     = { Type="Pistol",  Rarity="Epic",      Price= 9800, Damage= 62, FireRate=0.55,  MagSize=6,  ReloadTime=1.8, Range=240, Spread=0.018, Auto=false },  -- was 70
+	["Stinger Storm"]  = { Type="SMG",     Rarity="Epic",      Price= 6750, Damage= 12, FireRate=0.075, MagSize=35, ReloadTime=1.9, Range=170, Spread=0.035, Auto=true },  -- price was 7500 (-10%)
+	["Phantom Apex"]   = { Type="Rifle",   Rarity="Epic",      Price= 7200, Damage= 21, FireRate=0.13,  MagSize=30, ReloadTime=2.2, Range=340, Spread=0.013, Auto=true },  -- price was 8000 (-10%)
+	["Wraith Frost"]   = { Type="Sniper",  Rarity="Epic",      Price= 7650, Damage=190, FireRate=1.15,  MagSize=6,  ReloadTime=3.0, Range=520, Spread=0.005, Auto=false }, -- price was 8500 (-10%)
+	["Phantom Whisper"]= { Type="Rifle",   Rarity="Epic",      Price= 8100, Damage= 25, FireRate=0.15,  MagSize=24, ReloadTime=2.4, Range=360, Spread=0.011, Auto=true, Silent=true },  -- price was 9000 (-10%) (Silent unchanged)
+	["Thunder Royal"]  = { Type="Shotgun", Rarity="Epic",      Price= 8800, Damage= 13, Pellets=8, FireRate=0.70, MagSize=6, ReloadTime=2.6, Range=60, Spread=0.09, Auto=false },  -- price was 9800 (-10% rounded)
+	["Viper Left"]     = { Type="Pistol",  Rarity="Epic",      Price= 8800, Damage= 62, FireRate=0.55,  MagSize=6,  ReloadTime=1.8, Range=240, Spread=0.018, Auto=false },  -- price was 9800 (-10% rounded)
 
 	-- ===== Legendary (5) — 1.70x DPS =====
-	["Viper Aurum"]    = { Type="Pistol",  Rarity="Legendary", Price=16000, Damage= 51, FireRate=0.40,  MagSize=12, ReloadTime=1.4, Range=260, Spread=0.015, Auto=false },  -- was 60
-	["Phantom Finale"] = { Type="Rifle",   Rarity="Legendary", Price=18000, Damage= 24, FireRate=0.13,  MagSize=30, ReloadTime=2.1, Range=360, Spread=0.012, Auto=true },  -- was 60
-	["Wraith Apex"]    = { Type="Sniper",  Rarity="Legendary", Price=20000, Damage=206, FireRate=1.10,  MagSize=6,  ReloadTime=2.9, Range=560, Spread=0.004, Auto=false }, -- was 170
-	["Thunder Crown"]  = { Type="Shotgun", Rarity="Legendary", Price=22000, Damage= 14, Pellets=8, FireRate=0.65, MagSize=6, ReloadTime=2.5, Range=65, Spread=0.085, Auto=false },  -- was 22
-	["Hailstorm"]      = { Type="Minigun", Rarity="Legendary", Price=25000, Damage= 18, FireRate=0.05,  MagSize=120,ReloadTime=4.5, Range=220, Spread=0.055, Auto=true, SpinUp=0.5 },  -- unchanged (option B)
+	["Viper Aurum"]    = { Type="Pistol",  Rarity="Legendary", Price=12800, Damage= 51, FireRate=0.40,  MagSize=12, ReloadTime=1.4, Range=260, Spread=0.015, Auto=false },  -- price was 16000 (-20%)
+	["Phantom Finale"] = { Type="Rifle",   Rarity="Legendary", Price=14400, Damage= 24, FireRate=0.13,  MagSize=30, ReloadTime=2.1, Range=360, Spread=0.012, Auto=true },  -- price was 18000 (-20%)
+	["Wraith Apex"]    = { Type="Sniper",  Rarity="Legendary", Price=16000, Damage=206, FireRate=1.10,  MagSize=6,  ReloadTime=2.9, Range=560, Spread=0.004, Auto=false }, -- price was 20000 (-20%)
+	["Thunder Crown"]  = { Type="Shotgun", Rarity="Legendary", Price=17600, Damage= 14, Pellets=8, FireRate=0.65, MagSize=6, ReloadTime=2.5, Range=65, Spread=0.085, Auto=false },  -- price was 22000 (-20%)
+	["Hailstorm"]      = { Type="Minigun", Rarity="Legendary", Price=20000, Damage= 18, FireRate=0.05,  MagSize=120,ReloadTime=4.5, Range=220, Spread=0.055, Auto=true, SpinUp=0.5 },  -- price was 25000 (-20%) (Damage unchanged option B)
 
 	-- ===== Demon (4) — 1.90x DPS =====
-	["Fang Demon"]     = { Type="Knife",   Rarity="Demon",     Price=35000, Damage= 76, AttackRate=0.50, Range=10 },  -- was 120
-	["Phantom Hellfire"]= {Type="Rifle",   Rarity="Demon",     Price=42000, Damage= 27, FireRate=0.13,  MagSize=30, ReloadTime=2.0, Range=380, Spread=0.012, Auto=true, Burn=true },  -- was 75 (Burn unchanged)
-	["Wraith Abyss"]   = { Type="Sniper",  Rarity="Demon",     Price=48000, Damage=220, FireRate=1.05,  MagSize=5,  ReloadTime=2.8, Range=600, Spread=0.003, Auto=false, Pierce=true },  -- was 210 (Pierce unchanged)
-	["Thunder Bloodmoon"]={Type="Shotgun", Rarity="Demon",     Price=55000, Damage= 14, Pellets=8, FireRate=0.60, MagSize=6, ReloadTime=2.3, Range=70, Spread=0.080, Auto=false },  -- was 28
+	["Fang Demon"]     = { Type="Knife",   Rarity="Demon",     Price=26250, Damage= 76, AttackRate=0.50, Range=10 },  -- price was 35000 (-25%)
+	["Phantom Hellfire"]= {Type="Rifle",   Rarity="Demon",     Price=31500, Damage= 27, FireRate=0.13,  MagSize=30, ReloadTime=2.0, Range=380, Spread=0.012, Auto=true, Burn=true },  -- price was 42000 (-25%) (Burn unchanged)
+	["Wraith Abyss"]   = { Type="Sniper",  Rarity="Demon",     Price=36000, Damage=220, FireRate=1.05,  MagSize=5,  ReloadTime=2.8, Range=600, Spread=0.003, Auto=false, Pierce=true },  -- price was 48000 (-25%) (Pierce unchanged)
+	["Thunder Bloodmoon"]={Type="Shotgun", Rarity="Demon",     Price=41250, Damage= 14, Pellets=8, FireRate=0.60, MagSize=6, ReloadTime=2.3, Range=70, Spread=0.080, Auto=false },  -- price was 55000 (-25%)
 }
 
 -- Default starter weapons — every player owns these from the start, no purchase needed

--- a/verification/sprint-8b-runtime-checks.lua
+++ b/verification/sprint-8b-runtime-checks.lua
@@ -1,7 +1,10 @@
 --!strict
 -- verification/sprint-8b-runtime-checks.lua
 --
--- Reproducible Sprint 8b runtime verification.
+-- Reproducible balance-contract runtime verification.
+-- Originally a Sprint 8b artifact (filename kept for backref stability);
+-- now also covers Sprint 9a price realignment. Future sprints either
+-- extend this file or split into a sibling.
 --
 -- Usage:
 --   1. Open the Final Strike Studio place file
@@ -12,15 +15,26 @@
 --   5. Paste this entire file's contents and press Enter
 --   6. Check Output window for the [VERIFY] lines — every check should
 --      end with "OK" (green-ish prefix). Any "FAIL" prefix means runtime
---      drifted from the Sprint 8b design contract.
+--      drifted from a covered design contract.
 --
--- Equivalently, run just the assertion section via execute_luau over MCP
--- (see receipts/sprint-8b-studio-verify.md §"Static config verification").
+-- Equivalently, run via execute_luau over MCP (the script's `return`
+-- gives a structured `{ passed, failed, failures, hasNpcs, hadHud }`).
 --
 -- This script is read-only — it inspects state but doesn't mutate anything.
 --
--- Source of truth this checks against: proposals/30-weapon-dps-retune.md §9
--- + receipts/sprint-8b-200hp-rebalance.md.
+-- Sources of truth checked:
+--   - proposals/30-weapon-dps-retune.md §9 (Sprint 8b damage / config)
+--   - proposals/demon-shop-price-realignment.md §5 (Sprint 9a prices)
+--   - receipts/sprint-8b-200hp-rebalance.md
+--   - receipts/sprint-9a-demon-price-realign.md
+--
+-- Static check count = 92 (= 2 base + 6 rarity + 30 weapon damage + 5 sniper
+-- type + 6 enemies HP/dmg + 4 loot table + 3 weapon-drop-removed + 6 LOOT
+-- entries + 30 weapon prices). Conditional: +6 NPC (PvE only), +1 HUD.
+-- Possible totals by context:
+--   Lobby (no NPC, HUD ready):     92 + 0 + 1 = 93
+--   PvE (NPC + HUD):                92 + 6 + 1 = 99
+--   Server-only / no LocalPlayer:   92 (or 98 if NPC present)
 
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local Players = game:GetService("Players")
@@ -217,8 +231,9 @@ end
 -- output is the human-readable result.
 --
 -- hasNpcs / hadHud flags let callers explain why `passed` count varied —
--- e.g. (passed=63, hadHud=true, hasNpcs=false) means script was run in
--- lobby (62 static + 1 HUD), no drift, just no NPC sample.
+-- e.g. (passed=93, hadHud=true, hasNpcs=false) means script was run in
+-- lobby (92 static + 1 HUD), no drift, just no NPC sample. See header
+-- count table for all valid totals (92/93/98/99).
 return {
 	passed = pass,
 	failed = fail,

--- a/verification/sprint-8b-runtime-checks.lua
+++ b/verification/sprint-8b-runtime-checks.lua
@@ -93,6 +93,36 @@ for _, name in ipairs({"Wraith Scout", "Wraith Hunter", "Wraith Frost", "Wraith 
 end
 
 -- ============================================================
+-- 3.5. 30-weapon Price values (Sprint 9 Option A — CEO 2026-05-04)
+-- Tier discounts: Common 0% / Uncommon 0% / Rare -5% / Epic -10% / Legendary -20% / Demon -25%
+-- See proposals/demon-shop-price-realignment.md.
+-- ============================================================
+local priceExpect = {
+	-- Common (5) — 0% (unchanged)
+	["Viper Mk1"]=300, ["Viper SD"]=350, ["Fang Scout"]=450,
+	["Thunder Stub"]=550, ["Thunder Cut"]=650,
+	-- Uncommon (5) — 0% (unchanged)
+	["Stinger Mk2"]=1200, ["Stinger Tac"]=1350, ["Phantom Ranger"]=1500,
+	["Wraith Scout"]=1650, ["Stinger Burst"]=1800,
+	-- Rare (5) — -5%
+	["Reaver-X"]=2850, ["Phantom Night"]=3150, ["Thunder Guard"]=3400,
+	["Wraith Hunter"]=3800, ["Thunder Triple"]=4275,
+	-- Epic (6) — -10%
+	["Stinger Storm"]=6750, ["Phantom Apex"]=7200, ["Wraith Frost"]=7650,
+	["Phantom Whisper"]=8100, ["Thunder Royal"]=8800, ["Viper Left"]=8800,
+	-- Legendary (5) — -20%
+	["Viper Aurum"]=12800, ["Phantom Finale"]=14400, ["Wraith Apex"]=16000,
+	["Thunder Crown"]=17600, ["Hailstorm"]=20000,
+	-- Demon (4) — -25%
+	["Fang Demon"]=26250, ["Phantom Hellfire"]=31500, ["Wraith Abyss"]=36000,
+	["Thunder Bloodmoon"]=41250,
+}
+for name, expected in pairs(priceExpect) do
+	local cfg = GameConfig.WEAPONS[name]
+	check("WEAPONS." .. name .. ".Price", cfg and cfg.Price, expected)
+end
+
+-- ============================================================
 -- 4. NPC HP / Damage ×2 + 4-tier loot drop tables
 -- ============================================================
 check("ENEMIES.Patrol.HP",      GameConfig.ENEMIES.Patrol.HP,      120)


### PR DESCRIPTION
## Summary

Sprint 9a 實作。CEO 2026-05-04 拍板 Option A — tier-graduated 商店折扣，解決 Sprint 8b (b) 決議帶來的 Demon 武器「DPS 收斂但價格沒動」失衡問題。

## Files Changed

- `src/ReplicatedStorage/GameConfig.lua` — 20 weapon Price 值 + 註解 block
- `verification/sprint-8b-runtime-checks.lua` — 新增 §3.5 共 30 個 Price assertions
- `receipts/sprint-9a-demon-price-realign.md` — receipt（per-tier + per-weapon 雙層表 + 算式 + price/DPS 驗證）

## Discounts applied

| Rarity | 折扣 | Weapons | 範例 |
|---|---|---|---|
| Common | 0% | 5 (unchanged) | Viper Mk1: 300 → 300 |
| Uncommon | 0% | 5 (unchanged) | Wraith Scout: 1650 → 1650 |
| Rare | **-5%** | 5 | Wraith Hunter: 4000 → **3800** |
| Epic | **-10%** | 6 | Phantom Apex: 8000 → **7200** |
| Legendary | **-20%** | 5 | Wraith Apex: 20000 → **16000** |
| Demon | **-25%** | 4 | Wraith Abyss: 48000 → **36000**, Thunder Bloodmoon: 55000 → **41250** |

## Verification

```
{ passed = 30, failed = 0 }
```

跑 verification script §3.5 priceExpect 30 weapons 全 pass on running Studio post-realignment.

## Damage 不變

只動 Price，不動 Damage。Sprint 8b retune 過的 30 武器 Damage 值維持 unchanged（Wraith Scout 120, Wraith Abyss 220, Fang Demon 76, Hailstorm 18 等）。

## DPS-per-coin curve（target hit）

Demon price/DPS：23684（pre-realignment）→ **17763**（Option A，-25%）。仍比舊世界 15000 高 +18% — 接受 trade-off，保留「Demon = elite tier」進階感。

## Migration concerns（無）

- DataStore key unchanged → 已擁有武器的玩家不受影響
- 已花 50K coins 買 Demon 的玩家：武器留著，coins 不退（patch note material — 見 proposal §6）
- ShopController UI 自動讀新 Price，不需改 client code

## Test plan

- [x] Static config: verification script 30/30 prices ✓ (self-tested)
- [ ] Studio MCP playtest: 開 ShopUI 確認新價格顯示 + 用新價格實際買武器
- [ ] Demon 玩家 patch note 草擬（建議 Sprint 9b polish 一起做）

🤖 Generated with [Claude Code](https://claude.com/claude-code)