### PR TITLE
fix(lobby): #41 banner GUI face — flip Back→Front so text is visible

### DIFF
--- a/src/ServerScriptService/MapBuilder.lua
+++ b/src/ServerScriptService/MapBuilder.lua
@@ -639,7 +639,10 @@ function MAP.upgradeLobbyVisuals(lobby)
 		addLight(strip, Color3.fromRGB(255, 60, 50), 1.5, 30)
 	end
 	local bannerGui = Instance.new("SurfaceGui")
-	bannerGui.Face = Enum.NormalId.Back
+	-- (#41) Face=Front (-Z) so the GUI faces the spawn at z=-10. The original
+	-- comment incorrectly labeled NormalId.Back as the -Z face; Back is +Z
+	-- (away from spawn) so the text was rendered on the unseen far side.
+	bannerGui.Face = Enum.NormalId.Front
 	bannerGui.LightInfluence = 0
 	bannerGui.SizingMode = Enum.SurfaceGuiSizingMode.PixelsPerStud
 	bannerGui.PixelsPerStud = 50


### PR DESCRIPTION
## Summary
The banner labels (FINAL STRIKE / ONE LIFE / WHO SHOOTS WHO WINS / WHO DOESN'T SHOOT WHO DIES FIRST) were rendered on the wrong face of \`BannerWall\`. Verified live in Studio playtest: with \`Face=Front\`, all four labels are now clearly visible from spawn.

## Root cause
\`bannerGui.Face = Enum.NormalId.Back\` was paired with a misleading comment "\-Z face, visible from inside the room". In Roblox, \`NormalId.Back\` is the **+Z** face. With BannerWall at z=39 and spawn at z=-10, the GUI was on the +Z face (z=39.5), facing away from the player. The dark BannerWall part itself was visible (which is why earlier raycast verification said the banner was "reachable"), but the text rendered on the unseen far side.

## Why earlier verification missed it
- \`execute_luau\` confirmed the SurfaceGui contained 4 TextLabel children → ✅ but said nothing about which face
- Raycast from eye level hit the BannerWall part → ✅ but a part is reachable regardless of which face has the GUI
- Lesson: visual screenshot inspection in playtest is what actually caught it

## Reference
The sibling \`shopGui\` on \`GunShopBack\` (also viewed from -Z direction) uses \`Face=Front\` and renders correctly.

## Test plan
- [x] Playtest in Studio — all four banner labels visible from spawn (screenshot in commit message)
- [x] Server confirmed Face=Front via inspection

🤖 Generated with [Claude Code](https://claude.com/claude-code)