### PR TITLE
fix(training): #37 round 3 — clear inTraining flag on death/respawn

### DIFF
--- a/src/ServerScriptService/MapBuilder.lua
+++ b/src/ServerScriptService/MapBuilder.lua
@@ -639,7 +639,10 @@ function MAP.upgradeLobbyVisuals(lobby)
 		addLight(strip, Color3.fromRGB(255, 60, 50), 1.5, 30)
 	end
 	local bannerGui = Instance.new("SurfaceGui")
-	bannerGui.Face = Enum.NormalId.Back
+	-- (#41) Face=Front (-Z) so the GUI faces the spawn at z=-10. The original
+	-- comment incorrectly labeled NormalId.Back as the -Z face; Back is +Z
+	-- (away from spawn) so the text was rendered on the unseen far side.
+	bannerGui.Face = Enum.NormalId.Front
 	bannerGui.LightInfluence = 0
 	bannerGui.SizingMode = Enum.SurfaceGuiSizingMode.PixelsPerStud
 	bannerGui.PixelsPerStud = 50

--- a/src/ServerScriptService/TrainingService.lua
+++ b/src/ServerScriptService/TrainingService.lua
@@ -224,7 +224,44 @@ Players.PlayerRemoving:Connect(function(player)
 	lastExitTick[player] = nil
 end)
 
--- (#37) On real-match start, sweep stale training state defensively.
+-- (#37 round 3) The flag was getting stuck at true when a player died inside
+-- the training arena (live NPCs can kill them) — Roblox respawns them at
+-- LobbySpawn but the flag never cleared, so the next portal touch hit the
+-- "already inTraining" reject. Clear the flag in two places: on Humanoid.Died,
+-- and on CharacterAdded if the new character spawns outside the training
+-- arena bounds. CharacterAdded covers any other respawn path (manual reset,
+-- LoadCharacter from MatchManager, etc).
+local TRAINING_CENTER = Vector3.new(500, 0, 0)
+local TRAINING_RADIUS = 100   -- training floor is 120x120, so 70-80 fits comfortably
+
+local function clearStale(player, reason)
+	if inTraining[player] then
+		inTraining[player] = nil
+		lastEnterTick[player] = nil
+		print(string.format("[TrainingService] cleared inTraining for %s (%s)", player.Name, reason))
+	end
+end
+
+local function attachCharHooks(player)
+	local function onCharAdded(char)
+		local hum = char:WaitForChild("Humanoid", 5)
+		if hum then
+			hum.Died:Connect(function() clearStale(player, "Humanoid.Died") end)
+		end
+		-- After spawn settles, check if character is outside training bounds.
+		task.wait(0.3)
+		local hrp = char:FindFirstChild("HumanoidRootPart")
+		if hrp and (hrp.Position - TRAINING_CENTER).Magnitude > TRAINING_RADIUS then
+			clearStale(player, "respawn outside training")
+		end
+	end
+	if player.Character then task.spawn(onCharAdded, player.Character) end
+	player.CharacterAdded:Connect(onCharAdded)
+end
+for _, p in ipairs(Players:GetPlayers()) do attachCharHooks(p) end
+Players.PlayerAdded:Connect(attachCharHooks)
+
+-- On real-match start, sweep stale training state defensively.
 task.spawn(function()
 	local mm
 	for _ = 1, 50 do


### PR DESCRIPTION
## Diagnosis (live, on CEO's running session)

CEO walked over the training portal but no teleport. Confirmed via client-fired \`SelectTrainingWeapon\` → server responded with \`EquipWeapon\`, which only happens when \`inTraining[player]\` is true. So the server thought CEO was in training while they were actually in the lobby.

## Root cause

Training arena has live NPCs that can kill the player. Sequence:
1. Player enters training → \`inTraining[player] = true\`
2. NPC kills player → Roblox respawns at LobbySpawn
3. Player is now in lobby, but \`inTraining\` was never cleared
4. Player walks to portal → \`tryEnterTraining\` first check is \`if inTraining[player] then ... return\` → silent reject in proximity poll path

Round 1 (clear on PvE phase) didn't help because no match started. Round 2 (proximity poll) couldn't help — its first check is the same \`inTraining\` flag.

## Fix

Two new defenses:
1. **\`Humanoid.Died\`** — clears \`inTraining[player]\` immediately when killed
2. **\`CharacterAdded\`** — when a new character spawns more than 100 studs from training arena center (500, 0, 0), clear the flag. Covers any respawn path: death, manual reset, \`LoadCharacter\` from \`MatchManager.resetToLobby\`, etc.

Both attached to current players on script load + new joiners via \`Players.PlayerAdded\`.

## Test plan
- [ ] Enter training arena, get killed by NPC, walk back to portal — should re-enter
- [ ] Play one match, return to lobby, walk to training portal — should enter
- [ ] Verify console shows \`[TrainingService] cleared inTraining for ... (Humanoid.Died|respawn outside training)\`

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)