### PR TITLE
fix(lobby): NPC TRAINING ARENA text squish on arch sign

### DIFF
--- a/src/ServerScriptService/MapBuilder.lua
+++ b/src/ServerScriptService/MapBuilder.lua
@@ -639,7 +639,10 @@ function MAP.upgradeLobbyVisuals(lobby)
 		addLight(strip, Color3.fromRGB(255, 60, 50), 1.5, 30)
 	end
 	local bannerGui = Instance.new("SurfaceGui")
-	bannerGui.Face = Enum.NormalId.Back
+	-- (#41) Face=Front (-Z) so the GUI faces the spawn at z=-10. The original
+	-- comment incorrectly labeled NormalId.Back as the -Z face; Back is +Z
+	-- (away from spawn) so the text was rendered on the unseen far side.
+	bannerGui.Face = Enum.NormalId.Front
 	bannerGui.LightInfluence = 0
 	bannerGui.SizingMode = Enum.SurfaceGuiSizingMode.PixelsPerStud
 	bannerGui.PixelsPerStud = 50

--- a/src/ServerScriptService/MapBuilder.lua
+++ b/src/ServerScriptService/MapBuilder.lua
@@ -745,8 +745,14 @@ function MAP.upgradeLobbyVisuals(lobby)
 		Material = Enum.Material.SmoothPlastic,
 		Parent = lobby,
 	})
+	-- (#41) Explicit PixelsPerStud sizing keeps the 14:3 surface aspect correct
+	-- so "NPC TRAINING ARENA" doesn't render vertically squished. Same fix as
+	-- the GUN SHOP SurfaceGui.
 	local archGui = Instance.new("SurfaceGui")
 	archGui.Face = Enum.NormalId.Right  -- +X face (toward room interior)
+	archGui.SizingMode = Enum.SurfaceGuiSizingMode.PixelsPerStud
+	archGui.PixelsPerStud = 50
+	archGui.LightInfluence = 0
 	archGui.Parent = archSign
 	local archLbl = Instance.new("TextLabel")
 	archLbl.Size = UDim2.new(1, 0, 1, 0)
@@ -755,6 +761,8 @@ function MAP.upgradeLobbyVisuals(lobby)
 	archLbl.TextColor3 = Color3.fromRGB(255, 60, 50)
 	archLbl.TextScaled = true
 	archLbl.Font = Enum.Font.GothamBold
+	archLbl.TextStrokeColor3 = Color3.fromRGB(0, 0, 0)
+	archLbl.TextStrokeTransparency = 0.3
 	archLbl.Parent = archGui
 	-- Touch pad in front of the arch — TrainingService listens for Touched
 	local trainingPad = makePart({


### PR DESCRIPTION
## Summary
CEO reported the **NPC TRAINING ARENA** text on the lobby arch sign was vertically compressed.

## Root cause
Same SurfaceGui aspect-ratio bug as the GUN SHOP fix in #41. The \`TrainingArchSign\` part is 14 deep × 3 tall (14:3 aspect), but SurfaceGui defaults to \`FixedSize\` 800×600 (4:3) — that 4:3 canvas gets stretched into a 14:3 surface, squishing text vertically.

## Fix
- \`archGui.SizingMode = PixelsPerStud\` + \`PixelsPerStud = 50\` → canvas auto-derives from surface (700×150 px, matches 14:3 aspect)
- Add \`LightInfluence = 0\` and \`TextStrokeTransparency = 0.3\` for consistency with banner/shop signs

## Test plan
- [x] Verified live in Studio playtest (screenshot shows clean two-line "NPC TRAINING / ARENA" with normal aspect)

🤖 Generated with [Claude Code](https://claude.com/claude-code)