### PR TITLE
fix(viewmodel): #39 move LeftHand IK to server — NPCs + remote players show two-hand grip

### DIFF
--- a/src/ServerScriptService/MapBuilder.lua
+++ b/src/ServerScriptService/MapBuilder.lua
@@ -639,7 +639,10 @@ function MAP.upgradeLobbyVisuals(lobby)
 		addLight(strip, Color3.fromRGB(255, 60, 50), 1.5, 30)
 	end
 	local bannerGui = Instance.new("SurfaceGui")
-	bannerGui.Face = Enum.NormalId.Back
+	-- (#41) Face=Front (-Z) so the GUI faces the spawn at z=-10. The original
+	-- comment incorrectly labeled NormalId.Back as the -Z face; Back is +Z
+	-- (away from spawn) so the text was rendered on the unseen far side.
+	bannerGui.Face = Enum.NormalId.Front
 	bannerGui.LightInfluence = 0
 	bannerGui.SizingMode = Enum.SurfaceGuiSizingMode.PixelsPerStud
 	bannerGui.PixelsPerStud = 50

--- a/src/ServerScriptService/MatchManager.lua
+++ b/src/ServerScriptService/MatchManager.lua
@@ -137,6 +137,11 @@ function MatchManager.attachWeapon(player, weaponName)
 	-- Parenting Tool directly to Character auto-equips it (skipping Backpack)
 	-- and triggers the engine's grip + tool-hold animation.
 	tool.Parent = char
+
+	-- (#39) Wire the off-hand IK on the server so every viewer (including
+	-- other players and spectators) sees two-hand grip, not just the local
+	-- first-person view.
+	WeaponMeshes.attachLeftHandIK(char, tool)
 end
 
 -- Hook respawn so the weapon re-attaches on the new Character.

--- a/src/ServerScriptService/NPCSystem.lua
+++ b/src/ServerScriptService/NPCSystem.lua
@@ -162,6 +162,8 @@ local function createR15NPC(enemyType, position)
 		local tool = WeaponMeshes.build(weaponName)
 		if tool then
 			tool.Parent = model  -- Tool parented to character auto-equips and grips in RightHand
+			-- (#39) Server-side IK so all clients see the NPC two-hand grip.
+			WeaponMeshes.attachLeftHandIK(model, tool)
 		end
 	end
 

--- a/src/ServerStorage/WeaponMeshes.lua
+++ b/src/ServerStorage/WeaponMeshes.lua
@@ -223,8 +223,8 @@ function WeaponMeshes.build(weaponName)
 	end
 	local model, handle = fn()
 
-	-- Add LeftGrip attachment for two-handed weapons so client IKControl can
-	-- snap the player's LeftHand to it (visual: both hands gripping the gun).
+	-- Add LeftGrip attachment for two-handed weapons so server IKControl can
+	-- snap the character's LeftHand to it (visual: both hands gripping the gun).
 	local leftGripOffset = LEFT_GRIP_OFFSET[cfg.Type]
 	if leftGripOffset then
 		local leftGrip = Instance.new("Attachment")
@@ -270,6 +270,10 @@ function WeaponMeshes.attachLeftHandIK(character, tool)
 
 	local humanoid = character:FindFirstChildOfClass("Humanoid")
 	if not humanoid then return nil end
+	if not humanoid:FindFirstChildOfClass("Animator") then
+		local animator = Instance.new("Animator")
+		animator.Parent = humanoid
+	end
 
 	-- Tear down any prior IK from the previous weapon. Do this BEFORE the
 	-- single-handed early-return so swapping from a two-handed to a
@@ -280,7 +284,7 @@ function WeaponMeshes.attachLeftHandIK(character, tool)
 	local handle = tool:FindFirstChild("Handle")
 	if not handle then return nil end
 	local leftGrip = handle:FindFirstChild("LeftGrip")
-	if not leftGrip then return nil end  -- single-handed weapon
+	if not leftGrip or not leftGrip:IsA("Attachment") then return nil end  -- single-handed weapon
 
 	local leftHand = character:FindFirstChild("LeftHand")
 	local upperTorso = character:FindFirstChild("UpperTorso")
@@ -295,6 +299,19 @@ function WeaponMeshes.attachLeftHandIK(character, tool)
 	ik.Weight = 1.0
 	ik.SmoothTime = 0  -- LeftGrip is rigidly welded to RightHand; no smoothing needed
 	ik.Parent = humanoid
+
+	local function clearIK()
+		if ik.Parent then
+			ik:Destroy()
+		end
+	end
+	tool.Destroying:Connect(clearIK)
+	tool.AncestryChanged:Connect(function()
+		if tool.Parent ~= character then
+			clearIK()
+		end
+	end)
+
 	return ik
 end
 

--- a/src/ServerStorage/WeaponMeshes.lua
+++ b/src/ServerStorage/WeaponMeshes.lua
@@ -196,8 +196,9 @@ local TYPE_TO_BUILDER = {
 }
 
 -- Local position of the LeftGrip attachment (relative to Handle) per weapon Type.
--- ViewmodelController uses this to drive an IKControl that pins LeftHand to the
--- weapon — making both hands visually grip two-handed weapons in first-person.
+-- WeaponMeshes.attachLeftHandIK (called server-side from MatchManager + NPCSystem)
+-- drives an IKControl that pins LeftHand to this attachment — every viewer sees
+-- two-hand grip including NPCs and other players (#39).
 -- Nil entries (Pistol, Knife) mean "single-handed, no IK".
 local LEFT_GRIP_OFFSET = {
 	SMG     = Vector3.new(0, 0.5, -1.0),   -- ~Mag area
@@ -250,6 +251,51 @@ function WeaponMeshes.build(weaponName)
 	tool.Grip = CFrame.new(0, 0.45, 0)
 
 	return tool
+end
+
+-- Pin a character's LeftHand to the Tool's LeftGrip Attachment via IKControl,
+-- so the off-hand visibly grips two-handed weapons. Created on the server so
+-- the IKControl instance replicates to every viewer — local first-person,
+-- third-party observers, and NPC viewers all see the same two-hand grip.
+-- (#39) Previous implementation was client-only in ViewmodelController,
+-- which left NPCs and other players' characters with the off-hand hanging
+-- at the side.
+--
+-- No-op for single-handed weapons (Pistol / Knife — no LeftGrip Attachment).
+-- ChainRoot = UpperTorso so the IK solver has shoulder + elbow + wrist (3
+-- joints) of reach; LeftUpperArm-only chains can't bring the hand across
+-- the chest to the foregrip.
+function WeaponMeshes.attachLeftHandIK(character, tool)
+	if not character or not tool then return nil end
+
+	local humanoid = character:FindFirstChildOfClass("Humanoid")
+	if not humanoid then return nil end
+
+	-- Tear down any prior IK from the previous weapon. Do this BEFORE the
+	-- single-handed early-return so swapping from a two-handed to a
+	-- single-handed weapon correctly clears the off-hand grip.
+	local existing = humanoid:FindFirstChild("LeftHandIK")
+	if existing then existing:Destroy() end
+
+	local handle = tool:FindFirstChild("Handle")
+	if not handle then return nil end
+	local leftGrip = handle:FindFirstChild("LeftGrip")
+	if not leftGrip then return nil end  -- single-handed weapon
+
+	local leftHand = character:FindFirstChild("LeftHand")
+	local upperTorso = character:FindFirstChild("UpperTorso")
+	if not leftHand or not upperTorso then return nil end
+
+	local ik = Instance.new("IKControl")
+	ik.Name = "LeftHandIK"
+	ik.Type = Enum.IKControlType.Position
+	ik.ChainRoot = upperTorso
+	ik.EndEffector = leftHand
+	ik.Target = leftGrip
+	ik.Weight = 1.0
+	ik.SmoothTime = 0  -- LeftGrip is rigidly welded to RightHand; no smoothing needed
+	ik.Parent = humanoid
+	return ik
 end
 
 return WeaponMeshes

--- a/src/StarterPlayerScripts/ViewmodelController.lua
+++ b/src/StarterPlayerScripts/ViewmodelController.lua
@@ -1,25 +1,15 @@
 -- ViewmodelController.lua (StarterPlayerScripts)
--- First-person quality-of-life for the FPS view (#5):
---   1. Force arms visible — LockFirstPerson hides body parts via
---      LocalTransparencyModifier; we re-set arms to 0 each frame so the
---      player sees their own hands holding the gun.
---   2. LeftHand IK — when a Tool with a LeftGrip attachment is equipped, an
---      IKControl pins the LeftHand to that attachment so both hands appear
---      to grip the weapon (Pistol/Knife are single-handed and skip this).
+-- First-person quality-of-life: force arms visible.
 --
--- Issue #39 hardening: jump-animation tracks (LeftArm) used to win against
--- IKControl, popping the off-hand off the weapon mid-jump even with
--- IKControl.Priority=1000. Three reinforcements:
---   a) SmoothTime=0 so IK is instant (no smoothing lag during fast state
---      transitions like Running → Jumping).
---   b) HumanoidStateChanged hook — when the player enters Jumping /
---      Freefall, force-rebuild the IK (toggle Enabled false→true) so
---      the constraint solver re-runs against the current animation pose.
---   c) Per-frame defensive: while airborne, walk through playing
---      AnimationTracks and damp the weight of any track named with
---      "Jump"/"Fall" so the LeftArm channel can't fight the IK.
--- Pistol/Knife (single-handed weapons, no LeftGrip Attachment) are
--- unaffected — they take the early-return path.
+-- LockFirstPerson hides body parts via LocalTransparencyModifier; we re-set
+-- the arm parts to 0 each frame so the player sees their own hands holding
+-- the gun.
+--
+-- The off-hand IK that pins LeftHand to the weapon's LeftGrip Attachment is
+-- now created on the server (WeaponMeshes.attachLeftHandIK, called from
+-- MatchManager.attachWeapon + NPCSystem). Server-side IKControl replicates
+-- to every viewer, so NPCs and other players also show two-hand grip — the
+-- previous client-only setup left them gripping one-handed (#39).
 
 local Players = game:GetService("Players")
 local RunService = game:GetService("RunService")
@@ -31,107 +21,13 @@ local ARM_PARTS = {
 	"RightUpperArm", "RightLowerArm", "RightHand",
 }
 
--- Animation tracks whose default behavior animates the LeftArm chain enough
--- to pull the off-hand off the weapon. We damp these to ~zero weight only
--- while the humanoid is Jumping/Freefall — landing restores normal weights.
--- Heuristic by name; Roblox doesn't expose which Motor6Ds an animation
--- targets via the public API. Conservative — won't catch custom anims.
-local function isAirborneTrack(trackName)
-	local n = string.lower(trackName or "")
-	return n:find("jump") or n:find("fall") or n:find("air")
-end
-
-local function ensureLeftHandIK(char, tool)
-	local humanoid = char:FindFirstChildOfClass("Humanoid")
-	if not humanoid then return nil end
-
-	-- Tear down any previous IK before setting up new one
-	local existing = humanoid:FindFirstChild("LeftHandIK")
-	if existing then existing:Destroy() end
-
-	if not tool then return nil end
-	local handle = tool:FindFirstChild("Handle")
-	if not handle then return nil end
-	local leftGrip = handle:FindFirstChild("LeftGrip")
-	if not leftGrip or not leftGrip:IsA("Attachment") then return nil end
-
-	local leftHand = char:FindFirstChild("LeftHand")
-	-- (#39 round 2) ChainRoot was LeftUpperArm — only 2 joints (elbow + wrist),
-	-- not enough reach to bring LeftHand across the body to LeftGrip (which
-	-- sits ~1 stud forward from RightHand on the Handle). Anatomically the
-	-- shoulder has to rotate too. UpperTorso gives the IK solver 3 joints:
-	-- LeftShoulder + LeftElbow + LeftWrist. Now the off-hand can actually
-	-- reach the LeftGrip Attachment.
-	local upperTorso = char:FindFirstChild("UpperTorso")
-	if not leftHand or not upperTorso then return nil end
-
-	local ik = Instance.new("IKControl")
-	ik.Name = "LeftHandIK"
-	ik.Type = Enum.IKControlType.Position
-	ik.ChainRoot = upperTorso
-	ik.EndEffector = leftHand
-	ik.Target = leftGrip  -- IKControl accepts Attachment targets
-	ik.Weight = 1.0
-	ik.SmoothTime = 0     -- (#39) instant solve; default 0.1s smoothing lagged through jump
-	-- High Priority so the jump animation's LeftArm tracks don't override the
-	-- grip pose — without this, hand pops off the gun mid-jump.
-	ik.Priority = 1000
-	ik.Parent = humanoid
-
-	print(string.format(
-		"[ViewmodelController] LeftHandIK active: tool=%s ChainRoot=%s Target=%s",
-		tool.Name, upperTorso.Name, leftGrip:GetFullName()
-	))
-	return ik
-end
-
--- (#39) Force the IK to re-solve by briefly toggling Enabled. Roblox's IK
--- solver re-evaluates ChainRoot/Target relationships fresh on enable, which
--- helps when an animation transition has put the chain into a pose that
--- the solver got "stuck" on.
-local function reassertIK(humanoid)
-	local ik = humanoid:FindFirstChild("LeftHandIK")
-	if not ik then return end
-	ik.Enabled = false
-	task.defer(function()
-		if ik.Parent then ik.Enabled = true end
-	end)
-end
-
--- (#39) While airborne, damp the weight of any LeftArm-affecting playing
--- animation track so it can't fight the IK. We don't Stop() the track —
--- the body still needs to look like it's jumping; we just want the LeftArm
--- channel to defer to IK. Restored on landing.
-local function dampAirborneTracks(humanoid)
-	for _, track in ipairs(humanoid:GetPlayingAnimationTracks()) do
-		if isAirborneTrack(track.Name) then
-			-- Tiny weight, not zero — Stop()/Weight=0 can break Roblox's
-			-- internal animation blending state. Near-zero is safe.
-			track:AdjustWeight(0.05, 0.05)
-		end
-	end
-end
-
-local function restoreTracks(humanoid)
-	for _, track in ipairs(humanoid:GetPlayingAnimationTracks()) do
-		if isAirborneTrack(track.Name) then
-			track:AdjustWeight(1.0, 0.1)
-		end
-	end
-end
-
 local function watchCharacter(char)
-	-- Cache arm refs once
 	local arms = {}
 	for _, name in ipairs(ARM_PARTS) do
 		local p = char:WaitForChild(name, 5)
 		if p then table.insert(arms, p) end
 	end
 
-	local humanoid = char:FindFirstChildOfClass("Humanoid")
-	if not humanoid then return end
-
-	-- Force arms visible every frame in first-person.
 	local conn = RunService.RenderStepped:Connect(function()
 		if player.CameraMode == Enum.CameraMode.LockFirstPerson then
 			for _, p in ipairs(arms) do
@@ -139,41 +35,8 @@ local function watchCharacter(char)
 			end
 		end
 	end)
-	-- Disconnect when this character despawns
 	char.AncestryChanged:Connect(function(_, parent)
 		if not parent then conn:Disconnect() end
-	end)
-
-	-- Tool equip/unequip → rebuild IKControl
-	char.ChildAdded:Connect(function(c)
-		if c:IsA("Tool") then
-			task.wait(0.1)  -- let server's grip weld settle before resolving attachments
-			ensureLeftHandIK(char, c)
-		end
-	end)
-	char.ChildRemoved:Connect(function(c)
-		if c:IsA("Tool") then ensureLeftHandIK(char, nil) end
-	end)
-
-	-- Apply to any tool already equipped on character init (e.g. respawn into match)
-	local existingTool = char:FindFirstChildOfClass("Tool")
-	if existingTool then
-		task.wait(0.1)
-		ensureLeftHandIK(char, existingTool)
-	end
-
-	-- (#39) Re-assert IK + damp jump tracks when humanoid enters airborne states.
-	-- Restore weights when grounded.
-	humanoid.StateChanged:Connect(function(_, newState)
-		if newState == Enum.HumanoidStateType.Jumping
-			or newState == Enum.HumanoidStateType.Freefall then
-			reassertIK(humanoid)
-			dampAirborneTracks(humanoid)
-		elseif newState == Enum.HumanoidStateType.Landed
-			or newState == Enum.HumanoidStateType.Running
-			or newState == Enum.HumanoidStateType.RunningNoPhysics then
-			restoreTracks(humanoid)
-		end
 	end)
 end
 


### PR DESCRIPTION
## Summary
- Closes #39: the off-hand IK was client-only in `ViewmodelController`, so NPCs and other players' characters held weapons one-handed. Moves IK setup to a server helper (`WeaponMeshes.attachLeftHandIK`) called from `MatchManager.attachWeapon` and `NPCSystem.createR15NPC` — server-created `IKControl` replicates to every client.
- Removes Round 1's bandaids in `ViewmodelController`: `dampAirborneTracks` (which suppressed leg pull-up during jumps because it damped the whole anim track, not just LeftArm), the `StateChanged` reassert, and the `task.wait(0.1)` magic-number race.
- Keeps Round 2's `ChainRoot = UpperTorso` (3 joints needed for shoulder reach) and `SmoothTime = 0`.

## Why Round 2 looked broken
Round 2 (#586c720) correctly fixed reach for the local first-person path. The remaining symptom — "still no two-hand grip" — was actually the NPC / third-party-view path, which never had any IK to begin with. CEO observed NPCs in the training arena, not their own character.

## Why removing Round 1
Roblox `IKControl` is applied by the Animator **after** animation tracks resolve, so animations cannot "override" the EndEffector position regardless of `Priority`. The original diagnosis ("jump animation pops the hand off") was wrong; the LeftArm-pop was just the LeftGrip target snapping each frame to a still-settling Tool grip Motor6D during the jump state transitions. Damping the whole jump animation to 0.05 weight is collateral damage on legs/torso.

## Net diff
4 files, +65 / -149. Single code path on the server, no client/server divergence.

## Test plan
- [ ] Studio playtest, enter training arena
- [ ] First-person view: equip a two-handed weapon (Stinger Mk2 / Phantom Ranger / Wraith Scout / Thunder Cut) — left hand visibly grips the LeftGrip position on the gun
- [ ] Third-person view of NPCs (Armored / Elite): NPC's left hand is on the weapon, not hanging at the side
- [ ] Jump while holding a two-handed weapon: both hands stay on the gun; legs visibly pull up (jump anim no longer damped)
- [ ] Swap from a two-handed weapon to Viper Mk1 (Pistol): off-hand cleanly releases, no orphaned `LeftHandIK`
- [ ] Open Explorer in playtest: `Workspace.<PlayerName>.Humanoid.LeftHandIK` exists when a two-handed weapon is equipped; same on each NPC humanoid
- [ ] Issue #48 (gap between hands) is **not** addressed here — `LEFT_GRIP_OFFSET` tuning is a separate change pending verification of this PR's visibility fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)