### PR TITLE
fix(npc): #53 #56 disable server-side LeftHand IK + training AI profile

### DIFF
--- a/src/ReplicatedStorage/GameConfig.lua
+++ b/src/ReplicatedStorage/GameConfig.lua
@@ -171,12 +171,19 @@ GameConfig.ENEMIES = {
 	},
 }
 
--- (#53) Training arena NPCs walk at this fraction of their live-match Speed
--- so weapon visuals, hit reactions, and combat readability are observable.
--- AttackRate, AttackRange, DetectRange, HP, and Damage are unaffected — only
--- WalkSpeed is multiplied. Applied in NPCSystem.spawnDummyAt; live-match
--- spawns (NPCSystem.spawnWave) are untouched.
+-- (#53) Training-arena NPC behavior profile. Live-match values (per-enemy
+-- Speed / DetectRange above) are untouched; these only apply when a Tool is
+-- spawned via NPCSystem.spawnDummyAt and stamped with IsTrainingDummy=true.
+-- The goal is "observable practice target", not "live combat at half speed":
+--   1) walk slowly so visuals are readable
+--   2) only react when the player is genuinely close — no across-arena aggro
+--   3) stay near the spawn marker (small patrol radius + leash on chase)
+-- AttackRate / AttackRange / HP / Damage stay at match values so combat is
+-- still meaningful once the player closes in.
 GameConfig.TRAINING_SPEED_MULTIPLIER = 0.3
+GameConfig.TRAINING_DETECT_RANGE    = 18   -- vs live 35-50; player must approach
+GameConfig.TRAINING_PATROL_RADIUS   = 6    -- vs live ±30; tight wander around home
+GameConfig.TRAINING_LEASH_RADIUS    = 20   -- abort chase if pulled past this from home
 
 -- Loot pickup values — Sprint 8b: 4-tier medkit ladder (200 HP rebalance).
 -- Weapon drops remain removed (weapons are shop-only).

--- a/src/ReplicatedStorage/GameConfig.lua
+++ b/src/ReplicatedStorage/GameConfig.lua
@@ -176,7 +176,7 @@ GameConfig.ENEMIES = {
 -- AttackRate, AttackRange, DetectRange, HP, and Damage are unaffected — only
 -- WalkSpeed is multiplied. Applied in NPCSystem.spawnDummyAt; live-match
 -- spawns (NPCSystem.spawnWave) are untouched.
-GameConfig.TRAINING_SPEED_MULTIPLIER = 0.5
+GameConfig.TRAINING_SPEED_MULTIPLIER = 0.3
 
 -- Loot pickup values — Sprint 8b: 4-tier medkit ladder (200 HP rebalance).
 -- Weapon drops remain removed (weapons are shop-only).

--- a/src/ReplicatedStorage/GameConfig.lua
+++ b/src/ReplicatedStorage/GameConfig.lua
@@ -171,6 +171,13 @@ GameConfig.ENEMIES = {
 	},
 }
 
+-- (#53) Training arena NPCs walk at this fraction of their live-match Speed
+-- so weapon visuals, hit reactions, and combat readability are observable.
+-- AttackRate, AttackRange, DetectRange, HP, and Damage are unaffected — only
+-- WalkSpeed is multiplied. Applied in NPCSystem.spawnDummyAt; live-match
+-- spawns (NPCSystem.spawnWave) are untouched.
+GameConfig.TRAINING_SPEED_MULTIPLIER = 0.5
+
 -- Loot pickup values — Sprint 8b: 4-tier medkit ladder (200 HP rebalance).
 -- Weapon drops remain removed (weapons are shop-only).
 GameConfig.LOOT = {

--- a/src/ServerScriptService/MatchManager.lua
+++ b/src/ServerScriptService/MatchManager.lua
@@ -138,9 +138,9 @@ function MatchManager.attachWeapon(player, weaponName)
 	-- and triggers the engine's grip + tool-hold animation.
 	tool.Parent = char
 
-	-- (#39) Wire the off-hand IK on the server so every viewer (including
-	-- other players and spectators) sees two-hand grip, not just the local
-	-- first-person view.
+	-- WeaponMeshes currently normalizes the RightGrip orientation here; the
+	-- off-hand IK path is disabled inside the module until a non-propulsive
+	-- grip mechanism replaces the old rigid solver (#56).
 	WeaponMeshes.attachLeftHandIK(char, tool)
 end
 

--- a/src/ServerScriptService/NPCSystem.lua
+++ b/src/ServerScriptService/NPCSystem.lua
@@ -408,7 +408,22 @@ local function runNPCAI(npcModel)
 		local detectRange = npcModel:GetAttribute("DetectRange")
 		local attackRange = npcModel:GetAttribute("AttackRange")
 
-		if closestPlayer and closestDist <= detectRange then
+		-- (#53) Training-arena leash: if the dummy has drifted too far from its
+		-- spawn marker, suppress chase (NPC heads back to its patrol home
+		-- instead of pursuing the player around the arena). Attack-range
+		-- contact still triggers attack — player came to us. Live-match NPCs
+		-- have no HomePosition, so leashed = false for them.
+		local home = npcModel:GetAttribute("HomePosition")
+		local leashed = false
+		if home and (root.Position - home).Magnitude > (GameConfig.TRAINING_LEASH_RADIUS or math.huge) then
+			leashed = true
+		end
+		local canEngage = closestPlayer and (
+			closestDist <= attackRange
+			or (closestDist <= detectRange and not leashed)
+		)
+
+		if canEngage then
 			if closestDist <= attackRange then
 				-- Attack
 				npcModel:SetAttribute("State", "Attack")
@@ -458,8 +473,13 @@ local function runNPCAI(npcModel)
 			-- Patrol
 			npcModel:SetAttribute("State", "Patrol")
 			if not patrolTarget or (root.Position - patrolTarget).Magnitude < 5 then
-				patrolTarget = root.Position + Vector3.new(
-					math.random(-30, 30), 0, math.random(-30, 30)
+				-- (#53) Training NPCs wander tight around their HomePosition so
+				-- they stay near their spawn marker. Live NPCs use the original
+				-- ±30 around current position.
+				local base = home or root.Position
+				local radius = home and (GameConfig.TRAINING_PATROL_RADIUS or 6) or 30
+				patrolTarget = base + Vector3.new(
+					math.random(-radius, radius), 0, math.random(-radius, radius)
 				)
 			end
 			humanoid:MoveTo(patrolTarget)
@@ -547,9 +567,12 @@ function NPCSystem.spawnDummyAt(marker)
 	local npc = createR15NPC(enemyType, marker.Position)
 	if not npc then return end
 	npc:SetAttribute("IsTrainingDummy", true)
-	-- (#53) Training NPCs walk at TRAINING_SPEED_MULTIPLIER × match Speed so
-	-- weapon visuals, hit reactions, and combat are observable. AttackRate
-	-- and AttackRange unchanged — they still shoot at full match cadence.
+	-- (#53) Training-arena behavior profile. WalkSpeed reduced; DetectRange
+	-- replaced with the training-specific value (overrides the per-enemy match
+	-- value set by createR15NPC). HomePosition tag drives the patrol/leash
+	-- logic in runNPCAI so the dummy stays near its spawn marker.
+	npc:SetAttribute("DetectRange", GameConfig.TRAINING_DETECT_RANGE)
+	npc:SetAttribute("HomePosition", marker.Position)
 	local hum = npc:FindFirstChildOfClass("Humanoid")
 	if hum then hum.WalkSpeed = hum.WalkSpeed * GameConfig.TRAINING_SPEED_MULTIPLIER end
 	-- (#33) Training dummies now move + shoot. Was anchored static targets;

--- a/src/ServerScriptService/NPCSystem.lua
+++ b/src/ServerScriptService/NPCSystem.lua
@@ -162,7 +162,8 @@ local function createR15NPC(enemyType, position)
 		local tool = WeaponMeshes.build(weaponName)
 		if tool then
 			tool.Parent = model  -- Tool parented to character auto-equips and grips in RightHand
-			-- (#39) Server-side IK so all clients see the NPC two-hand grip.
+			-- Normalizes RightGrip orientation; off-hand IK is disabled in
+			-- WeaponMeshes until a non-propulsive grip mechanism exists (#56).
 			WeaponMeshes.attachLeftHandIK(model, tool)
 		end
 	end

--- a/src/ServerScriptService/NPCSystem.lua
+++ b/src/ServerScriptService/NPCSystem.lua
@@ -547,6 +547,11 @@ function NPCSystem.spawnDummyAt(marker)
 	local npc = createR15NPC(enemyType, marker.Position)
 	if not npc then return end
 	npc:SetAttribute("IsTrainingDummy", true)
+	-- (#53) Training NPCs walk at TRAINING_SPEED_MULTIPLIER × match Speed so
+	-- weapon visuals, hit reactions, and combat are observable. AttackRate
+	-- and AttackRange unchanged — they still shoot at full match cadence.
+	local hum = npc:FindFirstChildOfClass("Humanoid")
+	if hum then hum.WalkSpeed = hum.WalkSpeed * GameConfig.TRAINING_SPEED_MULTIPLIER end
 	-- (#33) Training dummies now move + shoot. Was anchored static targets;
 	-- CEO requested mobile combat so practice is meaningful. We run the same
 	-- runNPCAI used for match NPCs — it patrols / chases / attacks the

--- a/src/ServerScriptService/NPCSystem.lua
+++ b/src/ServerScriptService/NPCSystem.lua
@@ -358,6 +358,9 @@ local function runNPCAI(npcModel)
 	npcModel:GetAttributeChangedSignal("HP"):Connect(function()
 		local hp = npcModel:GetAttribute("HP")
 		if hp <= 0 and npcModel:GetAttribute("State") ~= "Dead" then
+			if npcModel:GetAttribute("IsTrainingDummy") then
+				return
+			end
 			npcModel:SetAttribute("State", "Dead")
 			dropLoot(npcModel)
 
@@ -521,11 +524,11 @@ function NPCSystem.cleanup()
 end
 
 -- ============ TRAINING DUMMIES ============
--- Stationary practice targets that auto-respawn 3s after death. They use the
--- same R15 builder as combat NPCs (so they take damage via the HP attribute
--- chain in MatchManager.FireWeapon) but skip runNPCAI — no chase, no attack,
--- no patrol. Tracked separately from activeNPCs so the LOBBY-phase cleanup
--- doesn't sweep them away.
+-- Practice targets that auto-respawn 3s after death. They use the same R15
+-- builder as combat NPCs (so they take damage via the HP attribute chain in
+-- MatchManager.FireWeapon), but run with a training-specific movement profile.
+-- Tracked separately from activeNPCs so the LOBBY-phase cleanup doesn't sweep
+-- them away.
 
 local activeDummies = {}  -- list of NPC models currently in TrainingArena
 

--- a/src/ServerStorage/WeaponMeshes.lua
+++ b/src/ServerStorage/WeaponMeshes.lua
@@ -10,7 +10,6 @@
 -- polish sprint — fixes #9 (Stage 1 rename broke direct name lookup).
 
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
-local Players = game:GetService("Players")
 local GameConfig = require(ReplicatedStorage:WaitForChild("GameConfig"))
 
 local WeaponMeshes = {}
@@ -356,22 +355,30 @@ function WeaponMeshes.attachLeftHandIK(character, tool)
 	if not character or not tool then return nil end
 
 	-- (#56) Fix Avatar-Joint-Upgrade RightGripAttachment orientation. Modern
-	-- R15 rigs (Players:CreateHumanoidModelFromDescription output) set the
-	-- attachment's local CFrame to Rx(90) — its -Z (the "grip forward"
-	-- direction Roblox uses to align Handle) points along the fingers, which
-	-- is DOWN when the arm hangs at the side. Tool.Parent = character creates
-	-- a Weld with C0 = attachment.CFrame, so the gun's barrel inherits this
-	-- downward orientation and ends up pointing straight into the floor.
-	-- Previously the rigid-pin LeftHand IK was masking this — its kinematic
-	-- loop force-rotated the right arm into a horizontal pose. With IK
-	-- disabled (below), the bug surfaces. Reset Weld.C0 to identity rotation
-	-- while preserving the position offset. Handle.LookVector then tracks
+	-- R15 rigs (CreateHumanoidModelFromDescription output) set the attachment's
+	-- local CFrame to Rx(90) — its -Z (the "grip forward" direction Roblox
+	-- uses to align Handle) points along the fingers, which is DOWN when the
+	-- arm hangs at the side. Tool.Parent = character creates a Weld with
+	-- C0 = attachment.CFrame, so the gun's barrel inherits this downward
+	-- orientation and ends up pointing straight into the floor. Previously
+	-- the rigid-pin LeftHand IK was masking this — its kinematic loop
+	-- force-rotated the right arm into a horizontal pose. With IK disabled
+	-- (below), the bug surfaces. Reset Weld.C0 to identity rotation while
+	-- preserving the position offset; Handle.LookVector then tracks
 	-- RightHand.LookVector, so the gun follows the animation pose naturally.
-	local rh = character:FindFirstChild("RightHand")
-	local weld = rh and rh:FindFirstChild("RightGrip")
-	if weld then
-		weld.C0 = CFrame.new(weld.C0.Position)
-	end
+	--
+	-- The Weld is created by Roblox's Tool grip machinery; in practice it's
+	-- present immediately after Tool.Parent = character on the same frame,
+	-- but defensive bounded WaitForChild handles the (rare) deferred case
+	-- without silently skipping the reset.
+	task.spawn(function()
+		local rh = character:WaitForChild("RightHand", 2)
+		if not rh then return end
+		local weld = rh:WaitForChild("RightGrip", 2)
+		if weld and weld:IsA("Weld") then
+			weld.C0 = CFrame.new(weld.C0.Position)
+		end
+	end)
 
 	-- (#56) Disable server-side LeftHand IK entirely. On modern Avatar-Joint-Upgrade
 	-- rigs, AlignPosition.RigidityEnabled=true creates a closed kinematic loop
@@ -385,12 +392,15 @@ function WeaponMeshes.attachLeftHandIK(character, tool)
 	-- pin the hand 2.2 studs from the LeftGrip regardless of MaxForce (1k–50k
 	-- all measured the same gap). The rigid pin is the only path that closes
 	-- that distance, and it's also the only path that causes the drag.
-	-- Trade-off: NPCs and other players' characters lose the two-hand grip
-	-- visual (LeftHand hangs at side) — the original PR #39 intent. Acceptable
-	-- because RootPart drift is gameplay-breaking. Re-enable when we have a
-	-- non-propulsive grip mechanism (custom animation, or anchor-style pin).
-	-- ViewmodelController's first-person viewmodel IK is unaffected (cosmetic
-	-- model separate from the actual character).
+	-- Trade-off: ALL characters lose the two-hand grip visual — NPCs, other
+	-- players in third-person, AND the local player's first-person view of
+	-- their own arms. ViewmodelController only forces real character arms
+	-- visible in first-person (no separate cosmetic viewmodel rig), so when
+	-- the server IK is disabled the local view loses the off-hand pose too.
+	-- Accepted because the RootPart drift / NPC propulsion this caused was
+	-- gameplay-breaking. Re-enable when we have a non-propulsive grip
+	-- mechanism (custom animation, or an anchor-style pin that doesn't
+	-- close the kinematic chain).
 	if true then return nil end
 	-- luacheck: ignore (rest kept for reference / future re-enable)
 

--- a/src/ServerStorage/WeaponMeshes.lua
+++ b/src/ServerStorage/WeaponMeshes.lua
@@ -354,6 +354,14 @@ end
 function WeaponMeshes.attachLeftHandIK(character, tool)
 	if not character or not tool then return nil end
 
+	-- (#56) Skip IK on NPCs. On modern Avatar-Joint-Upgrade rigs this attaches
+	-- AlignPosition.RigidityEnabled=true between LeftHand and the gun's LeftGrip;
+	-- LeftHand → BallSocket joints → UpperTorso forms a closed kinematic loop
+	-- that drags HumanoidRootPart 4-5x WalkSpeed during locomotion. Players
+	-- need the off-hand grip in first person; NPCs are seen from third-party
+	-- distance where left-hand pose is irrelevant.
+	if character:GetAttribute("EnemyType") then return nil end
+
 	local humanoid = character:FindFirstChildOfClass("Humanoid")
 	if not humanoid then return nil end
 

--- a/src/ServerStorage/WeaponMeshes.lua
+++ b/src/ServerStorage/WeaponMeshes.lua
@@ -355,6 +355,24 @@ end
 function WeaponMeshes.attachLeftHandIK(character, tool)
 	if not character or not tool then return nil end
 
+	-- (#56) Fix Avatar-Joint-Upgrade RightGripAttachment orientation. Modern
+	-- R15 rigs (Players:CreateHumanoidModelFromDescription output) set the
+	-- attachment's local CFrame to Rx(90) — its -Z (the "grip forward"
+	-- direction Roblox uses to align Handle) points along the fingers, which
+	-- is DOWN when the arm hangs at the side. Tool.Parent = character creates
+	-- a Weld with C0 = attachment.CFrame, so the gun's barrel inherits this
+	-- downward orientation and ends up pointing straight into the floor.
+	-- Previously the rigid-pin LeftHand IK was masking this — its kinematic
+	-- loop force-rotated the right arm into a horizontal pose. With IK
+	-- disabled (below), the bug surfaces. Reset Weld.C0 to identity rotation
+	-- while preserving the position offset. Handle.LookVector then tracks
+	-- RightHand.LookVector, so the gun follows the animation pose naturally.
+	local rh = character:FindFirstChild("RightHand")
+	local weld = rh and rh:FindFirstChild("RightGrip")
+	if weld then
+		weld.C0 = CFrame.new(weld.C0.Position)
+	end
+
 	-- (#56) Disable server-side LeftHand IK entirely. On modern Avatar-Joint-Upgrade
 	-- rigs, AlignPosition.RigidityEnabled=true creates a closed kinematic loop
 	-- (LeftHand → BallSocket joints → UpperTorso) that drags HumanoidRootPart:

--- a/src/ServerStorage/WeaponMeshes.lua
+++ b/src/ServerStorage/WeaponMeshes.lua
@@ -10,6 +10,7 @@
 -- polish sprint — fixes #9 (Stage 1 rename broke direct name lookup).
 
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local Players = game:GetService("Players")
 local GameConfig = require(ReplicatedStorage:WaitForChild("GameConfig"))
 
 local WeaponMeshes = {}
@@ -354,13 +355,26 @@ end
 function WeaponMeshes.attachLeftHandIK(character, tool)
 	if not character or not tool then return nil end
 
-	-- (#56) Skip IK on NPCs. On modern Avatar-Joint-Upgrade rigs this attaches
-	-- AlignPosition.RigidityEnabled=true between LeftHand and the gun's LeftGrip;
-	-- LeftHand → BallSocket joints → UpperTorso forms a closed kinematic loop
-	-- that drags HumanoidRootPart 4-5x WalkSpeed during locomotion. Players
-	-- need the off-hand grip in first person; NPCs are seen from third-party
-	-- distance where left-hand pose is irrelevant.
-	if character:GetAttribute("EnemyType") then return nil end
+	-- (#56) Disable server-side LeftHand IK entirely. On modern Avatar-Joint-Upgrade
+	-- rigs, AlignPosition.RigidityEnabled=true creates a closed kinematic loop
+	-- (LeftHand → BallSocket joints → UpperTorso) that drags HumanoidRootPart:
+	--   - NPCs: 4-5x WalkSpeed propulsion (Armored vmag 9.82 vs ws 2.40,
+	--     Elite vmag 19.64 vs ws 4.20 in Studio A/B).
+	--   - Players: 0.7-2.5 stud/s drift while standing still — RootPart moves
+	--     even when MoveDirection=(0,0,0); 100% eliminated by destroying the
+	--     AlignPosition in A/B test.
+	-- Softening (RigidityEnabled=false) doesn't help: BallSocket joint limits
+	-- pin the hand 2.2 studs from the LeftGrip regardless of MaxForce (1k–50k
+	-- all measured the same gap). The rigid pin is the only path that closes
+	-- that distance, and it's also the only path that causes the drag.
+	-- Trade-off: NPCs and other players' characters lose the two-hand grip
+	-- visual (LeftHand hangs at side) — the original PR #39 intent. Acceptable
+	-- because RootPart drift is gameplay-breaking. Re-enable when we have a
+	-- non-propulsive grip mechanism (custom animation, or anchor-style pin).
+	-- ViewmodelController's first-person viewmodel IK is unaffected (cosmetic
+	-- model separate from the actual character).
+	if true then return nil end
+	-- luacheck: ignore (rest kept for reference / future re-enable)
 
 	local humanoid = character:FindFirstChildOfClass("Humanoid")
 	if not humanoid then return nil end

--- a/src/ServerStorage/WeaponMeshes.lua
+++ b/src/ServerStorage/WeaponMeshes.lua
@@ -196,9 +196,9 @@ local TYPE_TO_BUILDER = {
 }
 
 -- Local position of the LeftGrip attachment (relative to Handle) per weapon Type.
--- WeaponMeshes.attachLeftHandIK (called server-side from MatchManager + NPCSystem)
--- drives the off-hand grip solver — every viewer sees two-hand grip including
--- NPCs and other players (#39).
+-- WeaponMeshes.attachLeftHandIK is still called server-side from MatchManager
+-- and NPCSystem, but the off-hand solver is disabled for now (#56). The active
+-- path only normalizes RightGrip orientation so guns do not point into the floor.
 -- Nil entries (Pistol, Knife) mean "single-handed, no IK".
 --
 -- Avatar-Joint-Upgrade rigs cannot currently reach true foregrip targets with
@@ -339,16 +339,10 @@ local function clearLeftHandGrip(character)
 	restoreLeftArmAnimationConstraints(character)
 end
 
--- Pin a character's LeftHand to the Tool's LeftGrip Attachment. Modern Roblox
--- Avatar-Joint-Upgrade rigs use AnimationConstraint + BallSocketConstraint
--- joints instead of Motor6Ds, so IKControl is inert there; those rigs use an
--- AlignPosition pull while temporarily pausing the left arm animation drivers.
--- Legacy Motor6D rigs fall back to IKControl. Everything is server-created so
--- the grip replicates to every viewer: local first-person, third-party
--- observers, and NPC viewers all see the same two-hand grip.
--- (#39) Previous implementation was client-only in ViewmodelController,
--- which left NPCs and other players' characters with the off-hand hanging
--- at the side.
+-- Attach-time weapon pose maintenance. The off-hand solver below is currently
+-- disabled (#56); the live path only resets the RightGrip weld rotation. The
+-- old IK/AlignPosition implementation is left below the early return as
+-- reference for a future non-propulsive grip mechanism.
 --
 -- No-op for single-handed weapons (Pistol / Knife — no LeftGrip Attachment).
 function WeaponMeshes.attachLeftHandIK(character, tool)

--- a/src/StarterPlayerScripts/ViewmodelController.lua
+++ b/src/StarterPlayerScripts/ViewmodelController.lua
@@ -5,11 +5,10 @@
 -- the arm parts to 0 each frame so the player sees their own hands holding
 -- the gun.
 --
--- The off-hand IK that pins LeftHand to the weapon's LeftGrip Attachment is
--- now created on the server (WeaponMeshes.attachLeftHandIK, called from
--- MatchManager.attachWeapon + NPCSystem). Server-side IKControl replicates
--- to every viewer, so NPCs and other players also show two-hand grip — the
--- previous client-only setup left them gripping one-handed (#39).
+-- Server-side off-hand IK is currently disabled in WeaponMeshes (#56) because
+-- its rigid grip solver dragged character RootParts. This script only keeps
+-- the real character arms visible in first-person; it does not restore the
+-- two-hand pose.
 
 local Players = game:GetService("Players")
 local RunService = game:GetService("RunService")


### PR DESCRIPTION
## Summary
Training arena NPCs use the same WalkSpeed *and* AI profile as live-match NPCs, so even at half speed they sprint across the arena chasing the player (#53). Introduce a training-specific behavior profile in `GameConfig` and apply it in `NPCSystem.spawnDummyAt`. Live-match path (`spawnWave`) is untouched.

The branch also carries the #56 fixes that were already on `main`'s direction (server-side LeftHand IK disabled because `AlignPosition.RigidityEnabled` propelled NPCs at 4-5× WalkSpeed and drifted standing players, plus `RightGrip` Weld C0 reset so guns don't point into the floor).

## Changes
- `GameConfig.lua` — four constants: `TRAINING_SPEED_MULTIPLIER = 0.3`, `TRAINING_DETECT_RANGE = 18`, `TRAINING_PATROL_RADIUS = 6`, `TRAINING_LEASH_RADIUS = 20`
- `NPCSystem.spawnDummyAt` — override WalkSpeed, override `DetectRange` attribute, stamp `HomePosition` attribute on the dummy
- `NPCSystem.runNPCAI` —
  - leash check: suppress chase when NPC has drifted past `TRAINING_LEASH_RADIUS` from `HomePosition` (attack-range contact still triggers attack)
  - patrol now wanders ±`TRAINING_PATROL_RADIUS` around `HomePosition` instead of ±30 from current position
  - early return on HP-zero when `IsTrainingDummy` so `watchDummy` exclusively owns death+respawn (avoids `dropLoot` race)
- `WeaponMeshes.lua` —
  - server IK call kept as a no-op (`if true then return nil end`) with the rationale comment, marked re-enable when a non-propulsive grip mechanism exists
  - `RightGrip` Weld C0 reset via `task.spawn` + bounded `WaitForChild` so it's not order-dependent on Roblox's Tool-grip-weld creation
  - removed unused `Players` import

## Studio verification
6 NPCs in training arena, player teleported 50 stud away after spawn:

| State | NPCs in Patrol | NPCs in Chase |
|---|---|---|
| After spawn | 6 ✓ | 0 |
| After player teleports 50 stud away | **6 ✓** | **0** |

WalkSpeed: Patrol 3.6 / Armored 2.4 / Elite 4.2 stud/s (≤26% of player walk).
Distance from home stayed stable at 2.5–15 studs — within leash.
Live-match NPCs lack `HomePosition`, so the new logic short-circuits and their original behavior is preserved.

## Known regression (carried from `main` via #56)
Two-hand grip is now visually disabled for **all** characters, including the local player's first-person view of their own arms. `ViewmodelController` only forces arms visible via `LocalTransparencyModifier`; there is no separate cosmetic viewmodel rig, so server-side IK disable affects the local view too. Accepted because the `RigidityEnabled` propulsion bug it caused was gameplay-breaking; re-enable when we have a non-propulsive grip mechanism.

## Closes
- Closes #53

## Test plan
- [ ] Studio playtest, enter training arena via portal
- [ ] NPCs visibly walk slowly (not sprint) and stay near their spawn markers
- [ ] Player teleport across the arena — NPCs don't immediately aggro
- [ ] Kill a training dummy — confirm it respawns at the same marker after 3s (no `dropLoot` from runNPCAI)
- [ ] Live-match PvE phase: NPCs unchanged (chase fully, original Speed values)
- [ ] First-person view: off-hand visibly hangs at side (documented regression; #56 trade-off)
- [ ] Guns point along character forward direction, not into the floor (RightGrip C0 reset works on slow Roblox grip-weld timing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)