### PR TITLE
Add authoritative reload and R15 NPC aim poses

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,23 @@ A 12-player survival shooter for Roblox. PvE loot phase → PvP elimination.
 
 ## Architecture
 
-- **MatchManager.lua** - Core game loop (Lobby → PvE → PvP → End)
-- **MapBuilder.lua** - Procedural map generation (lobby, arena, spectator area)
-- **NPCSystem.lua** - R15 NPC spawning, AI, patrol, chase, attack, loot drops
-- **WeaponSystem.lua** - Gun/melee framework with fictional weapons
-- **LootSystem.lua** - Pickups: ammo, medkits, coins, weapons
-- **HealthSystem.lua** - Player HP, elimination, spectator teleport
-- **HUDController.lua** - Client-side HP bar, match phase, kill feed
-- **WeaponClient.lua** - Client-side weapon input, animations, FX
+- **GameConfig.lua** - Shared match, weapon, NPC, economy, and quest configuration
+- **GameEventsBootstrap.lua** - Runtime `GameEvents` RemoteEvent/RemoteFunction creation
+- **MatchManager.lua** - Lobby → PvE → PvP → Match End flow, player health, ammo, and weapon validation
+- **MapBuilder.lua** - Procedural Last Zone lobby, arena, spectator area, and training arena
+- **NPCSystem.lua** - R15 NPC spawning, AI, combat, training dummies, and loot drops
+- **LootSystem.lua** - Ammo, medkit, and coin pickups
+- **CurrencyService.lua / ShopService.lua** - BulletCoin persistence and 30-weapon ownership/loadout
+- **DailyQuestService.lua** - UTC-reset daily quest progress and rewards
+- **TrainingService.lua** - Training arena entry, exit, and unrestricted weapon selection
+- **WeaponMeshes.lua** - Tool-based weapon model builders and grip setup
+- **HUDController.lua / WeaponClient.lua** - HUD, firing input, reload input, and local weapon FX
+- **ViewmodelController.lua / CameraController.lua** - First-person arms, crosshair, and camera behavior
+- **ShopController.lua / DailyQuestUI.lua / TrainingArenaUI.lua** - Interactive client UI
+- **NPCWeaponEffectsClient.lua** - Client-only NPC muzzle flash and tracer FX
+
+## Verification
+
+- `verification/sprint-8b-runtime-checks.lua` contains reusable Studio runtime checks.
+- `src/ServerScriptService/Tests/` contains the Studio-only TestEZ suite; current automated coverage includes `CurrencyMath` and `ReloadLogic`.
+- The `2026-07-12` full-place Studio E2E in `最後一擊` covered the complete match lifecycle, manual/automatic/partial reload, reserve pickups, reload cancellation, and NPC R15 aim/fire poses.

--- a/TODOS.md
+++ b/TODOS.md
@@ -1,6 +1,7 @@
 # TODOS
 
-Deferred items from `/plan-eng-review` of `pr-7-conflict-fix` (2026-05-10).
+Deferred items from `/plan-eng-review` of `pr-7-conflict-fix` (2026-05-10),
+reconciled against `main` on 2026-07-11.
 Each entry: **What / Why / Pros / Cons / Context / Depends on**.
 
 ---
@@ -59,33 +60,6 @@ Each entry: **What / Why / Pros / Cons / Context / Depends on**.
 - **Context:** Documented as `_G.MatchManager`, `_G.CurrencyService`, etc. across the codebase. PR #7 follows this pattern consistently. The `_G` antipattern is in many Roblox tutorials but Knit / Aero / Nevermore are all `require`-based.
 - **Depends on:** Nothing. Worth doing before adding a 5th service.
 
-## Architecture: phase event signaling
-
-- **What:** Replace `while task.wait(1) do ... mm.CurrentPhase end` polling in `NPCSystem.lua:432-444` and `LootSystem.lua:113-127` with a server-side `BindableEvent` fired by `MatchManager.setPhase`.
-- **Why:** Pre-existing pattern. Polling adds 1s of perceived spawn lag and burns two perma-coroutines.
-- **Pros:** Instant NPC/loot spawn on phase change; cleaner architecture; no busy loop.
-- **Cons:** ~20 LOC change across three files.
-- **Context:** Comment in NPCSystem.lua:431 acknowledges this: "Since PhaseChanged fires to clients, we use _G to detect phase from MatchManager." Solution is a BindableEvent (server-only).
-- **Depends on:** Nothing.
-
-## Performance: BindToClose parallelization
-
-- **What:** In each persistent service's `BindToClose`, save players concurrently via `task.spawn` + a wait barrier instead of sequentially.
-- **Why:** With 12 players × 3 stores × ~200ms each = ~7s sequential. Risk grows under DataStore throttling. BindToClose has 30s budget.
-- **Pros:** ~3x faster shutdown; more headroom under throttling.
-- **Cons:** ~10 LOC per service; introduces concurrency that must be tested.
-- **Context:** Pre-existing pattern in CurrencyService.lua:159, ShopService.lua:193, DailyQuestService.lua:174.
-- **Depends on:** Nothing. Cheap win.
-
-## Performance: LootSystem bobbing → Heartbeat
-
-- **What:** Replace per-pickup `task.spawn` 33Hz bob loop with a single `RunService.Heartbeat` driving all active loot in one pass.
-- **Why:** ~8 pickups × 33 events/sec = 264 coroutine switches/sec. Negligible but unnecessary.
-- **Pros:** Cleaner; trivially scales to 100+ pickups.
-- **Cons:** ~15 LOC refactor.
-- **Context:** LootSystem.lua:39-48. Pre-existing pattern.
-- **Depends on:** Nothing.
-
 ## Performance: mobile rendering pass
 
 - **What:** Audit PointLight count, hit-spark Parts, NPC highlights, NPC PointLights for mobile FPS impact. Probable changes: cull distant lights, replace some hit sparks with ParticleEmitter.
@@ -94,25 +68,6 @@ Each entry: **What / Why / Pros / Cons / Context / Depends on**.
 - **Cons:** Requires actual mobile device testing or Roblox device emulator.
 - **Context:** Pre-existing pattern; PR #7 didn't make it worse.
 - **Depends on:** Mobile QA target audience confirmed.
-
-## Game design: `FirstWinDaily` reward
-
-- **What:** Either implement first-win-of-the-day bonus payout in `MatchManager.endMatch` or remove `GameConfig.ECONOMY.Rewards.FirstWinDaily` from config.
-- **Why:** `GameConfig.lua:100` defines it (`FirstWinDaily = 300`) but no code references it. Dead config.
-- **Pros (implement):** Real day-one retention hook — extra +300 on the day's first match win on top of `PlacementWin`.
-- **Pros (remove):** Clean up dead config.
-- **Cons (implement):** Requires per-player day-tracker (similar to DailyQuestService) — could just reuse DailyQuestService's `Date` field.
-- **Context:** Found during PR #7 review. Probably an artifact of an earlier scope that wasn't fully wired.
-- **Depends on:** Nothing.
-
-## Anti-cheat: rate-limit FireWeapon
-
-- **What:** Server-side per-player FireWeapon timestamp; reject calls faster than `weapon.FireRate * 0.9`.
-- **Why:** Issue 2 added an origin distance check. A cheater could still spam FireWeapon faster than the weapon's natural rate to multiply DPS within the legal radius.
-- **Pros:** Enforces fire-rate budget server-side; prevents auto-clicker / packet-spam exploits.
-- **Cons:** ~10 LOC per-player table; must account for client ping (allow some grace).
-- **Context:** Currently FireRate is enforced only on the client (`canFire = false; task.delay(FireRate, ...)`).
-- **Depends on:** Nothing.
 
 ## Game design: quest progress overflow handling
 
@@ -138,3 +93,16 @@ Bugs flagged during PR #7 eng-review Studio playtest, fixed in the same PR
 - **Loot pickup Touched fired per character part** — fixed with per-pickup
   `consumed` flag in both `LootSystem.createPickup` and `NPCSystem.dropLoot`,
   so a single coin no longer awards 6× currency before Destroy propagates.
+
+Completed after the original 2026-05-10 review:
+
+- **Server phase signaling** — `MatchManager.PhaseChangedServer` now uses a
+  `BindableEvent`; NPC and loot spawning no longer poll once per second.
+- **Parallel shutdown saves** — Currency, shop, and daily quest services now
+  save players concurrently with a bounded `BindToClose` wait.
+- **Central loot bob driver** — one `RunService.Heartbeat` loop now updates all
+  active pickups.
+- **First-win daily reward** — `MatchManager` calls
+  `DailyQuestService.claimFirstWinDailyIfAvailable`.
+- **Server fire-rate limit** — `MatchManager` rejects calls faster than 90% of
+  the configured fire/attack interval.

--- a/src/ReplicatedStorage/GameConfig.lua
+++ b/src/ReplicatedStorage/GameConfig.lua
@@ -16,6 +16,11 @@ GameConfig.SPAWN_PROTECTION = 3     -- seconds of NPC-damage immunity after tele
 GameConfig.MAX_HP = 200
 GameConfig.MEDKIT_HEAL = 100  -- legacy fallback; new code reads GameConfig.LOOT[tier].Heal directly
 
+-- Magazine economy. Players enter a match (or select a training weapon) with
+-- five spare magazines; ammo pickups add reserve rounds up to fifteen magazines.
+GameConfig.STARTING_RESERVE_MAGAZINES = 5
+GameConfig.MAX_RESERVE_MAGAZINES = 15
+
 -- Headshot multiplier — Sprint 8b only Sniper Type applies (D1 decision)
 -- See proposals/sprint-8-200hp-balance.md §3.5 for full rationale.
 GameConfig.HEADSHOT_MULTIPLIER = 2.0
@@ -94,6 +99,14 @@ GameConfig.WEAPONS = {
 	["Phantom Hellfire"]= {Type="Rifle",   Rarity="Demon",     Price=31500, Damage= 27, FireRate=0.13,  MagSize=30, ReloadTime=2.0, Range=380, Spread=0.012, Auto=true, Burn=true },  -- price was 42000 (-25%) (Burn unchanged)
 	["Wraith Abyss"]   = { Type="Sniper",  Rarity="Demon",     Price=36000, Damage=220, FireRate=1.05,  MagSize=5,  ReloadTime=2.8, Range=600, Spread=0.003, Auto=false, Pierce=true },  -- price was 48000 (-25%) (Pierce unchanged)
 	["Thunder Bloodmoon"]={Type="Shotgun", Rarity="Demon",     Price=41250, Damage= 14, Pellets=8, FireRate=0.60, MagSize=6, ReloadTime=2.3, Range=70, Spread=0.080, Auto=false },  -- price was 55000 (-25%)
+}
+
+-- Published R15 reload animations by matching weapon type. WeaponClient scales
+-- each clip to the weapon's ReloadTime; unlisted types use procedural R15 poses.
+GameConfig.RELOAD_ANIMATION_IDS = {
+	Pistol = 102338606855201,
+	Rifle = 99673558497035,
+	Shotgun = 70858423637669,
 }
 
 -- Default starter weapons — every player owns these from the start, no purchase needed

--- a/src/ReplicatedStorage/R15Pose.lua
+++ b/src/ReplicatedStorage/R15Pose.lua
@@ -1,0 +1,171 @@
+-- R15Pose.lua (ReplicatedStorage ModuleScript)
+-- Procedural upper-body poses for R15 AnimationConstraint and Motor6D rigs.
+-- It only writes existing animation-joint Transform values, never creates a
+-- physics constraint, and never writes HumanoidRootPart.
+
+local RunService = game:GetService("RunService")
+
+local R15Pose = {}
+local Controller = {}
+Controller.__index = Controller
+
+local JOINT_PAIRS = {
+	["RightUpperArm|UpperTorso"] = "RightShoulder",
+	["RightLowerArm|RightUpperArm"] = "RightElbow",
+	["RightHand|RightLowerArm"] = "RightWrist",
+	["LeftUpperArm|UpperTorso"] = "LeftShoulder",
+	["LeftLowerArm|LeftUpperArm"] = "LeftElbow",
+	["LeftHand|LeftLowerArm"] = "LeftWrist",
+}
+
+local TRACKED_JOINTS = {}
+for _, jointName in pairs(JOINT_PAIRS) do
+	TRACKED_JOINTS[jointName] = true
+end
+
+local function angles(x, y, z)
+	return CFrame.Angles(math.rad(x), math.rad(y), math.rad(z))
+end
+
+local function pairKey(first, second)
+	if first < second then return first .. "|" .. second end
+	return second .. "|" .. first
+end
+
+local function getConstraintJointName(constraint)
+	local attachment0 = constraint.Attachment0
+	local attachment1 = constraint.Attachment1
+	local part0 = attachment0 and attachment0.Parent
+	local part1 = attachment1 and attachment1.Parent
+	if not part0 or not part1 then return nil end
+	return JOINT_PAIRS[pairKey(part0.Name, part1.Name)]
+end
+
+R15Pose.Poses = {
+	TwoHandHold = {
+		RightShoulder = angles(-55, 0, 10),
+		RightElbow = angles(-25, 0, 0),
+		LeftShoulder = angles(-65, -10, -25),
+		LeftElbow = angles(-55, 0, 0),
+		LeftWrist = angles(0, 15, 0),
+	},
+	NPCAim = {
+		RightShoulder = angles(-75, 0, 5),
+		RightElbow = angles(-15, 0, 0),
+		LeftShoulder = angles(-72, -5, -18),
+		LeftElbow = angles(-45, 0, 0),
+		LeftWrist = angles(0, 10, 0),
+	},
+	NPCFire = {
+		RightShoulder = CFrame.new(0, 0, 0.06) * angles(-68, 0, 7),
+		RightElbow = angles(-22, 0, 0),
+		LeftShoulder = angles(-68, -5, -18),
+		LeftElbow = angles(-48, 0, 0),
+		LeftWrist = angles(0, 10, 0),
+	},
+	ReloadEject = {
+		RightShoulder = angles(-30, 0, 15),
+		RightElbow = angles(-55, 0, 0),
+		LeftShoulder = angles(-70, -15, -35),
+		LeftElbow = angles(-75, 0, 0),
+		LeftWrist = angles(15, 15, -10),
+	},
+	ReloadInsert = {
+		RightShoulder = angles(-35, 0, 12),
+		RightElbow = angles(-48, 0, 0),
+		LeftShoulder = angles(-55, -12, -28),
+		LeftElbow = angles(-65, 0, 0),
+		LeftWrist = angles(-10, 10, 5),
+	},
+	ReloadRack = {
+		RightShoulder = angles(-58, 0, 8),
+		RightElbow = angles(-30, 0, 0),
+		LeftShoulder = angles(-78, -5, -12),
+		LeftElbow = angles(-38, 0, 0),
+		LeftWrist = angles(0, 20, 0),
+	},
+}
+
+function R15Pose.new(character)
+	local self = setmetatable({
+		Character = character,
+		Joints = {},
+		Current = {},
+		Target = {},
+		BlendSpeed = math.huge,
+		BlendRemaining = 0,
+		Active = false,
+		Destroyed = false,
+	}, Controller)
+
+	local motorFallbacks = {}
+	for _, descendant in ipairs(character:GetDescendants()) do
+		if descendant:IsA("Motor6D") and TRACKED_JOINTS[descendant.Name] then
+			motorFallbacks[descendant.Name] = descendant
+		elseif descendant:IsA("AnimationConstraint") then
+			local jointName = getConstraintJointName(descendant)
+			if jointName then
+				self.Joints[jointName] = descendant
+			end
+		end
+	end
+	for name, motor in pairs(motorFallbacks) do
+		if not self.Joints[name] then self.Joints[name] = motor end
+	end
+	for name in pairs(self.Joints) do
+		self.Current[name] = CFrame.new()
+		self.Target[name] = CFrame.new()
+	end
+
+	self.StepConnection = RunService.PreSimulation:Connect(function(dt)
+		if self.Destroyed or not self.Active then return end
+		local alpha = (self.BlendRemaining <= dt or self.BlendSpeed == math.huge)
+			and 1
+			or (1 - math.exp(-self.BlendSpeed * dt))
+		for name, joint in pairs(self.Joints) do
+			if joint.Parent then
+				local current = self.Current[name]:Lerp(self.Target[name], alpha)
+				self.Current[name] = current
+				joint.Transform = current
+			end
+		end
+		self.BlendRemaining = math.max(0, self.BlendRemaining - dt)
+		self.Active = self.BlendRemaining > 0
+	end)
+
+	self.AncestryConnection = character.AncestryChanged:Connect(function(_, parent)
+		if not parent then self:Destroy() end
+	end)
+
+	return self
+end
+
+function Controller:IsSupported()
+	return self.Joints.RightShoulder ~= nil and self.Joints.LeftShoulder ~= nil
+end
+
+function Controller:SetPose(pose, blendTime)
+	if self.Destroyed then return end
+	self.BlendRemaining = math.max(blendTime or 0, 0)
+	self.BlendSpeed = self.BlendRemaining > 0 and (5 / self.BlendRemaining) or math.huge
+	self.Active = true
+	for name in pairs(self.Joints) do
+		self.Target[name] = pose[name] or CFrame.new()
+	end
+end
+
+function Controller:Reset(blendTime)
+	self:SetPose({}, blendTime)
+end
+
+function Controller:Destroy()
+	if self.Destroyed then return end
+	self.Destroyed = true
+	if self.StepConnection then self.StepConnection:Disconnect() end
+	if self.AncestryConnection then self.AncestryConnection:Disconnect() end
+	for _, joint in pairs(self.Joints) do
+		if joint.Parent then joint.Transform = CFrame.new() end
+	end
+end
+
+return R15Pose

--- a/src/ServerScriptService/GameEventsBootstrap.lua
+++ b/src/ServerScriptService/GameEventsBootstrap.lua
@@ -38,11 +38,11 @@ makeRemoteEvent("FireWeapon")          -- client → server: origin, direction, 
 makeRemoteEvent("WeaponHit")           -- server → client: hit effects
 makeRemoteEvent("EquipWeapon")         -- server → client: weaponName
 makeRemoteEvent("ReloadWeapon")        -- client → server
-makeRemoteEvent("ReloadComplete")      -- server → client
+makeRemoteEvent("ReloadStateChanged")  -- server → client: active, duration, weaponName
 
 -- Loot
 makeRemoteEvent("LootPickedUp")       -- server → client: lootType, amount
-makeRemoteEvent("AmmoUpdate")         -- server → client: current, max
+makeRemoteEvent("AmmoUpdate")         -- server → client: magazine, reserve, magSize
 
 -- NPC
 makeRemoteEvent("NPCDamaged")         -- visual feedback

--- a/src/ServerScriptService/LootSystem.lua
+++ b/src/ServerScriptService/LootSystem.lua
@@ -67,11 +67,7 @@ local function createPickup(lootType, position)
 		consumed = true
 
 		if lootType == "Ammo" then
-			data.Ammo = data.Ammo + GameConfig.LOOT.Ammo.Amount
-			-- AmmoUpdate max should reflect equipped weapon's MagSize, not a hardcoded 30 (Issue 4).
-			local weaponCfg = GameConfig.WEAPONS[data.Weapon]
-			local maxAmmo = (weaponCfg and weaponCfg.MagSize) or data.Ammo
-			events.AmmoUpdate:FireClient(player, data.Ammo, maxAmmo)
+			mm.addAmmo(player, GameConfig.LOOT.Ammo.Amount)
 		elseif lootType == "MedkitSmall" or lootType == "Medkit"
 		    or lootType == "MedkitLarge" or lootType == "MedkitFull" then
 			-- Sprint 8b: 4-tier medkit; heal amount lookup from GameConfig.LOOT[tier].Heal

--- a/src/ServerScriptService/MatchManager.lua
+++ b/src/ServerScriptService/MatchManager.lua
@@ -8,6 +8,7 @@ local ServerStorage = game:GetService("ServerStorage")
 -- Wait for modules
 local GameConfig = require(ReplicatedStorage:WaitForChild("GameConfig"))
 local WeaponMeshes = require(ServerStorage:WaitForChild("WeaponMeshes"))
+local ReloadLogic = require(ServerStorage:WaitForChild("ReloadLogic"))
 local events = ReplicatedStorage:WaitForChild("GameEvents")
 
 local PhaseChanged = events:WaitForChild("PhaseChanged")
@@ -15,6 +16,8 @@ local TimerUpdate = events:WaitForChild("TimerUpdate")
 local Announcement = events:WaitForChild("Announcement")
 local PlayerEliminated = events:WaitForChild("PlayerEliminated")
 local KillFeed = events:WaitForChild("KillFeed")
+local AmmoUpdate = events:WaitForChild("AmmoUpdate")
+local ReloadStateChanged = events:WaitForChild("ReloadStateChanged")
 
 -- Per-shot [Fire] debug logging. Auto weapons fire ~12 shots/sec and shotguns
 -- log per pellet, so this is OFF by default to avoid flooding the console
@@ -38,7 +41,14 @@ phaseChangedServer.Name = "PhaseChangedServer"
 MatchManager.PhaseChangedServer = phaseChangedServer.Event
 
 -- Player data store (per-match)
-local playerData = {}  -- [player] = { HP, Ammo, Coins, Weapon, Eliminated }
+local playerData = {}  -- [player] = { HP, MaxHP, Ammo, ReserveAmmo, Weapon, Eliminated, ProtectedUntil, Reloading, ReloadToken, ReloadEndsAt }
+
+local function pushAmmoState(player, data)
+	if player.Parent ~= Players then return end
+	local config = GameConfig.WEAPONS[data.Weapon]
+	local magSize = (config and config.MagSize) or 0
+	AmmoUpdate:FireClient(player, data.Ammo or 0, data.ReserveAmmo or 0, magSize)
+end
 
 -- Reward helper: routes through CurrencyService (which enforces per-match caps)
 -- and logs successful awards. Returns 0 if CurrencyService not loaded yet or capped.
@@ -79,18 +89,27 @@ function MatchManager.initPlayerData(player)
 	-- Use player's chosen primary weapon (from shop equip) — fallback to STARTER_WEAPONS
 	-- if ShopService isn't loaded or hasn't loaded the player yet.
 	local equipped = (_G.ShopService and _G.ShopService.getPrimary(player)) or GameConfig.STARTER_WEAPONS[1]
-	local equippedCfg = GameConfig.WEAPONS[equipped] or GameConfig.WEAPONS[GameConfig.STARTER_WEAPONS[1]]
+	if not GameConfig.WEAPONS[equipped] then
+		equipped = GameConfig.STARTER_WEAPONS[1]
+	end
+	local equippedCfg = GameConfig.WEAPONS[equipped]
 
 	-- Start each player with a full magazine of their equipped weapon (Issue 4).
 	-- Knives have no MagSize, so we fall back to 0 (knives ignore Ammo anyway).
 	local startingAmmo = equippedCfg.MagSize or 0
+	local previousData = playerData[player]
+	if previousData then ReloadLogic.cancel(previousData) end
 	playerData[player] = {
 		HP = GameConfig.MAX_HP,
 		MaxHP = GameConfig.MAX_HP,
 		Ammo = startingAmmo,
+		ReserveAmmo = startingAmmo * GameConfig.STARTING_RESERVE_MAGAZINES,
 		Weapon = equipped,
 		Eliminated = false,
 		ProtectedUntil = 0,  -- set after teleportToArena
+		Reloading = false,
+		ReloadToken = 0,
+		ReloadEndsAt = 0,
 	}
 	-- Send initial HP + ammo + equipped weapon. WeaponClient relies on
 	-- EquipWeapon to update its `currentWeapon`; without it the client
@@ -98,9 +117,95 @@ function MatchManager.initPlayerData(player)
 	-- Range/FireRate/Auto stats client-side.
 	local healthUpdate = events:WaitForChild("HealthUpdate")
 	healthUpdate:FireClient(player, GameConfig.MAX_HP, GameConfig.MAX_HP)
-	local ammoUpdate = events:WaitForChild("AmmoUpdate")
-	ammoUpdate:FireClient(player, startingAmmo, startingAmmo)
+	pushAmmoState(player, playerData[player])
+	ReloadStateChanged:FireClient(player, false, 0, equipped)
 	events:WaitForChild("EquipWeapon"):FireClient(player, equipped)
+end
+
+function MatchManager.syncAmmoState(player)
+	local data = playerData[player]
+	if data then pushAmmoState(player, data) end
+end
+
+local function pushReloadState(player, active, duration, weaponName)
+	if player.Parent == Players then
+		ReloadStateChanged:FireClient(player, active, duration or 0, weaponName)
+	end
+end
+
+function MatchManager.cancelReload(player)
+	local data = playerData[player]
+	if not data then return false end
+
+	local wasReloading = ReloadLogic.cancel(data)
+	if wasReloading then
+		pushReloadState(player, false, 0, data.Weapon)
+	end
+	return wasReloading
+end
+
+function MatchManager.syncReloadState(player)
+	local data = playerData[player]
+	if not data then
+		pushReloadState(player, false, 0, nil)
+		return
+	end
+
+	if data.Reloading then
+		local remaining = math.max(0, (data.ReloadEndsAt or 0) - tick())
+		pushReloadState(player, true, remaining, data.Weapon)
+	else
+		pushReloadState(player, false, 0, data.Weapon)
+	end
+end
+
+local function hasEquippedWeapon(player, weaponName)
+	local character = player.Character
+	local equippedTool = character and character:FindFirstChild(weaponName)
+	return equippedTool ~= nil and equippedTool:IsA("Tool")
+end
+
+function MatchManager.startReload(player)
+	local data = playerData[player]
+	if not data then return false end
+	if not hasEquippedWeapon(player, data.Weapon) then return false end
+
+	local config = GameConfig.WEAPONS[data.Weapon]
+	local operation = ReloadLogic.start(data, config, tick())
+	if not operation then return false end
+
+	pushReloadState(player, true, operation.Duration, operation.Weapon)
+	task.delay(operation.Duration, function()
+		if playerData[player] ~= data then return end
+		if not hasEquippedWeapon(player, operation.Weapon) then
+			MatchManager.cancelReload(player)
+			return
+		end
+		if not ReloadLogic.complete(data, operation, config) then return end
+
+		pushAmmoState(player, data)
+		pushReloadState(player, false, 0, operation.Weapon)
+	end)
+	return true
+end
+
+function MatchManager.addAmmo(player, amount)
+	local data = playerData[player]
+	if not data or data.Eliminated then return 0 end
+	if type(amount) ~= "number" or amount <= 0 then return 0 end
+
+	local config = GameConfig.WEAPONS[data.Weapon]
+	local magSize = config and config.MagSize
+	if type(magSize) ~= "number" or magSize <= 0 then return 0 end
+
+	local added = ReloadLogic.addReserve(
+		data,
+		config,
+		amount,
+		GameConfig.MAX_RESERVE_MAGAZINES
+	)
+	pushAmmoState(player, data)
+	return added
 end
 
 -- Build a weapon Tool and parent it to the player's Character so Roblox's
@@ -157,6 +262,9 @@ local ARENA_PHASES = {
 
 local function bindRespawnHook(player)
 	player.CharacterAdded:Connect(function()
+		-- A new character invalidates any reload animation/tool state tied to
+		-- the previous rig. Cancel before the client clears its local state.
+		MatchManager.cancelReload(player)
 		task.wait(0.5)  -- let R15 rig finish loading
 		if not ARENA_PHASES[MatchManager.CurrentPhase] then return end
 		local data = playerData[player]
@@ -217,6 +325,7 @@ function MatchManager.eliminatePlayer(player, killer)
 	local data = playerData[player]
 	if not data or data.Eliminated then return end
 
+	MatchManager.cancelReload(player)
 	data.Eliminated = true
 	MatchManager.AlivePlayers[player] = nil
 
@@ -356,6 +465,9 @@ function MatchManager.resetToLobby()
 	MatchManager.setPhase(GameConfig.PHASE.LOBBY)
 	MatchManager.AlivePlayers = {}
 	MatchManager.PvPEnabled = false
+	for player in pairs(playerData) do
+		MatchManager.cancelReload(player)
+	end
 	playerData = {}
 
 	-- Defensive Tool destroy (#35 / #38): even though LoadCharacter destroys
@@ -536,9 +648,11 @@ local lastFireTick = {}  -- [player] = tick() at last accepted shot
 Players.PlayerRemoving:Connect(function(player)
 	if MatchManager.AlivePlayers[player] then
 		MatchManager.AlivePlayers[player] = nil
-		playerData[player] = nil
 		MatchManager.checkWinCondition()
 	end
+	local data = playerData[player]
+	if data then ReloadLogic.cancel(data) end
+	playerData[player] = nil
 	lastFireTick[player] = nil  -- don't leak Player keys
 end)
 
@@ -588,6 +702,7 @@ events:WaitForChild("FireWeapon").OnServerEvent:Connect(function(player, origin,
 
 	local config = GameConfig.WEAPONS[weaponName]
 	if not config then return end
+	if data.Reloading then return end
 
 	-- Anti-cheat: server-side fire-rate limit. Reject calls faster than the
 	-- weapon's declared rate (with 10% slack for jitter). Without this, an
@@ -615,11 +730,14 @@ events:WaitForChild("FireWeapon").OnServerEvent:Connect(function(player, origin,
 		return
 	end
 
+	local shouldAutoReload = false
+
 	-- Ammo check
 	if config.Type ~= "Knife" then
 		if data.Ammo <= 0 then return end
 		data.Ammo = data.Ammo - 1
-		events.AmmoUpdate:FireClient(player, data.Ammo, config.MagSize)
+		pushAmmoState(player, data)
+		shouldAutoReload = data.Ammo == 0
 	end
 
 	-- Raycast
@@ -684,20 +802,17 @@ events:WaitForChild("FireWeapon").OnServerEvent:Connect(function(player, origin,
 			broadcastHitNearby(result.Position, result.Normal)
 		end
 	end
+
+	if shouldAutoReload then
+		MatchManager.startReload(player)
+	end
 end)
 
 -- Reload handler
 events:WaitForChild("ReloadWeapon").OnServerEvent:Connect(function(player)
-	local data = playerData[player]
-	if not data or data.Eliminated then return end
-
-	local config = GameConfig.WEAPONS[data.Weapon]
-	if not config or config.Type == "Knife" then return end
-
-	task.wait(config.ReloadTime)
-	data.Ammo = config.MagSize
-	events.AmmoUpdate:FireClient(player, data.Ammo, config.MagSize)
-	events.ReloadComplete:FireClient(player)
+	if not MatchManager.startReload(player) then
+		MatchManager.syncReloadState(player)
+	end
 end)
 
 -- Make MatchManager accessible to other scripts

--- a/src/ServerScriptService/NPCSystem.lua
+++ b/src/ServerScriptService/NPCSystem.lua
@@ -8,6 +8,7 @@ local PathfindingService = game:GetService("PathfindingService")
 local ServerStorage = game:GetService("ServerStorage")
 
 local GameConfig = require(ReplicatedStorage:WaitForChild("GameConfig"))
+local R15Pose = require(ReplicatedStorage:WaitForChild("R15Pose"))
 local WeaponMeshes = require(ServerStorage:WaitForChild("WeaponMeshes"))
 local events = ReplicatedStorage:WaitForChild("GameEvents")
 
@@ -23,6 +24,7 @@ local NPC_WEAPON = {
 
 local NPCSystem = {}
 local activeNPCs = {}
+local warnedUnsupportedPose = false
 
 -- PathfindingService agent params tuned for the standard R15 character
 -- (~2 stud wide, ~5 stud tall, default HipHeight ~2.2).
@@ -272,11 +274,7 @@ local function dropLoot(npcModel)
 				consumed = true
 
 				if lootType == "Ammo" then
-					data.Ammo = data.Ammo + GameConfig.LOOT.Ammo.Amount
-					-- AmmoUpdate max from equipped MagSize, not hardcoded 30 (Issue 4).
-					local weaponCfg = GameConfig.WEAPONS[data.Weapon]
-					local maxAmmo = (weaponCfg and weaponCfg.MagSize) or data.Ammo
-					events.AmmoUpdate:FireClient(player, data.Ammo, maxAmmo)
+					mm.addAmmo(player, GameConfig.LOOT.Ammo.Amount)
 				elseif lootType == "MedkitSmall" or lootType == "Medkit"
 				    or lootType == "MedkitLarge" or lootType == "MedkitFull" then
 					-- Sprint 8b: 4-tier medkit; heal amount lookup
@@ -311,6 +309,24 @@ local function runNPCAI(npcModel)
 	local config = GameConfig.ENEMIES[npcModel:GetAttribute("EnemyType")]
 	local lastAttack = 0
 	local patrolTarget = nil
+	local poseController = R15Pose.new(npcModel)
+	local poseState = nil
+
+	if not poseController:IsSupported() and not warnedUnsupportedPose then
+		warnedUnsupportedPose = true
+		warn("[NPCSystem] Procedural aim pose unavailable: this R15 rig has no supported arm animation joints")
+	end
+
+	local function setAIState(state)
+		npcModel:SetAttribute("State", state)
+		if state == poseState then return end
+		poseState = state
+		if state == "Attack" then
+			poseController:SetPose(R15Pose.Poses.NPCAim, 0.2)
+		else
+			poseController:Reset(0.2)
+		end
+	end
 
 	-- Pathfinding state for Chase mode
 	local path = PathfindingService:CreatePath(PATH_AGENT)
@@ -362,7 +378,7 @@ local function runNPCAI(npcModel)
 			if npcModel:GetAttribute("IsTrainingDummy") then
 				return
 			end
-			npcModel:SetAttribute("State", "Dead")
+			setAIState("Dead")
 			dropLoot(npcModel)
 
 			-- Death effect
@@ -385,7 +401,10 @@ local function runNPCAI(npcModel)
 	end)
 
 	-- AI loop
-	while npcModel.Parent and humanoid.Health > 0 do
+	while npcModel.Parent
+		and humanoid.Health > 0
+		and npcModel:GetAttribute("State") ~= "Dead"
+	do
 		local root = npcModel.PrimaryPart
 		if not root then break end
 
@@ -430,7 +449,7 @@ local function runNPCAI(npcModel)
 		if canEngage then
 			if closestDist <= attackRange then
 				-- Attack
-				npcModel:SetAttribute("State", "Attack")
+				setAIState("Attack")
 				humanoid:MoveTo(root.Position)  -- stop walking
 
 				-- Face the player before firing (#22) — only Y-axis rotation so
@@ -450,6 +469,12 @@ local function runNPCAI(npcModel)
 
 				if tick() - lastAttack >= npcModel:GetAttribute("AttackRate") then
 					lastAttack = tick()
+					poseController:SetPose(R15Pose.Poses.NPCFire, 0.04)
+					task.delay(0.1, function()
+						if npcModel.Parent and npcModel:GetAttribute("State") == "Attack" then
+							poseController:SetPose(R15Pose.Poses.NPCAim, 0.08)
+						end
+					end)
 					local mm = _G.MatchManager
 					if mm then
 						mm.damagePlayer(closestPlayer, npcModel:GetAttribute("Damage"))
@@ -469,13 +494,13 @@ local function runNPCAI(npcModel)
 				end
 			else
 				-- Chase via PathfindingService so NPCs route around cover
-				npcModel:SetAttribute("State", "Chase")
+				setAIState("Chase")
 				local targetPos = closestPlayer.Character.HumanoidRootPart.Position
 				chaseWithPath(root, targetPos)
 			end
 		else
 			-- Patrol
-			npcModel:SetAttribute("State", "Patrol")
+			setAIState("Patrol")
 			if not patrolTarget or (root.Position - patrolTarget).Magnitude < 5 then
 				-- (#53) Training NPCs wander tight around their HomePosition so
 				-- they stay near their spawn marker. Live NPCs use the original
@@ -491,6 +516,7 @@ local function runNPCAI(npcModel)
 
 		task.wait(0.3)
 	end
+	poseController:Destroy()
 end
 
 -- Spawn all NPCs from markers

--- a/src/ServerScriptService/Tests/README.md
+++ b/src/ServerScriptService/Tests/README.md
@@ -16,6 +16,7 @@ TestEZ-based unit tests for pure-logic helpers extracted from server services.
 | Module | Status | Notes |
 |--------|--------|-------|
 | `CurrencyMath.spec` | ✅ | 10 tests covering per-category cap, total cap, clamp, exhaustion. |
+| `ReloadLogic.spec` | ✅ | Reload eligibility, authoritative token/cancellation, stale operations, reserve-ammo accounting, partial reloads, and invalid config. |
 | `ShopService.spec` | ❌ TODO | `tryBuy` state machine. Blocked: ShopService.lua has DataStore + RemoteEvent side effects on require. Needs a similar `ShopLogic.lua` extraction. See TODOS.md. |
 | `DailyQuestService.spec` | ❌ TODO | `recordEvent` + `tryClaim` + `ensureFreshDay`. Same blocker as ShopService. |
 | `MatchManager.spec` | ❌ TODO | Placement math in `eliminatePlayer` (death order → top3/top5). Pure logic; needs extraction. |

--- a/src/ServerScriptService/Tests/ReloadLogic.spec.lua
+++ b/src/ServerScriptService/Tests/ReloadLogic.spec.lua
@@ -1,0 +1,163 @@
+-- ReloadLogic.spec.lua
+-- Pure-logic tests for authoritative reload state transitions.
+
+local ServerStorage = game:GetService("ServerStorage")
+local ReloadLogic = require(ServerStorage:WaitForChild("ReloadLogic"))
+
+return function()
+	local function freshData(ammo, reserveAmmo)
+		return {
+			Ammo = ammo,
+			ReserveAmmo = reserveAmmo == nil and 150 or reserveAmmo,
+			Weapon = "Phantom Ranger",
+			Eliminated = false,
+			Reloading = false,
+			ReloadToken = 0,
+			ReloadEndsAt = 0,
+		}
+	end
+
+	local rifle = {
+		Type = "Rifle",
+		MagSize = 30,
+		ReloadTime = 2.5,
+	}
+
+	describe("reserve pickups", function()
+		it("adds rounds without exceeding the magazine-based cap", function()
+			local data = freshData(12, 440)
+
+			expect(ReloadLogic.addReserve(data, rifle, 15, 15)).to.equal(10)
+			expect(data.ReserveAmmo).to.equal(450)
+			expect(ReloadLogic.addReserve(data, rifle, 15, 15)).to.equal(0)
+			expect(data.ReserveAmmo).to.equal(450)
+		end)
+
+		it("rejects invalid amounts and weapons without magazines", function()
+			local data = freshData(12, 10)
+
+			expect(ReloadLogic.addReserve(data, rifle, 0, 15)).to.equal(0)
+			expect(ReloadLogic.addReserve(data, { Type = "Knife" }, 15, 15)).to.equal(0)
+			expect(data.ReserveAmmo).to.equal(10)
+		end)
+	end)
+
+	describe("canStart", function()
+		it("allows a partial magazine", function()
+			expect(ReloadLogic.canStart(freshData(12), rifle)).to.equal(true)
+		end)
+
+		it("rejects full magazines, knives, eliminated players, and active reloads", function()
+			expect(ReloadLogic.canStart(freshData(30), rifle)).to.equal(false)
+
+			local knife = { Type = "Knife" }
+			expect(ReloadLogic.canStart(freshData(0), knife)).to.equal(false)
+
+			local eliminated = freshData(12)
+			eliminated.Eliminated = true
+			expect(ReloadLogic.canStart(eliminated, rifle)).to.equal(false)
+
+			local active = freshData(12)
+			active.Reloading = true
+			expect(ReloadLogic.canStart(active, rifle)).to.equal(false)
+		end)
+
+		it("rejects empty reserves and invalid weapon timing config", function()
+			expect(ReloadLogic.canStart(freshData(12, 0), rifle)).to.equal(false)
+			expect(ReloadLogic.canStart(freshData(12), {
+				Type = "Rifle",
+				MagSize = 0,
+				ReloadTime = 2.5,
+			})).to.equal(false)
+			expect(ReloadLogic.canStart(freshData(12), {
+				Type = "Rifle",
+				MagSize = 30,
+				ReloadTime = 0,
+			})).to.equal(false)
+		end)
+	end)
+
+	describe("start and complete", function()
+		it("records an authoritative token, weapon, duration, and end time", function()
+			local data = freshData(12)
+			local operation = ReloadLogic.start(data, rifle, 100)
+
+			expect(operation.Token).to.equal(1)
+			expect(operation.Weapon).to.equal("Phantom Ranger")
+			expect(operation.Duration).to.equal(2.5)
+			expect(operation.EndsAt).to.equal(102.5)
+			expect(data.Reloading).to.equal(true)
+		end)
+
+		it("fills the magazine only for the matching operation", function()
+			local data = freshData(12)
+			local operation = ReloadLogic.start(data, rifle, 100)
+
+			expect(ReloadLogic.complete(data, operation, rifle)).to.equal(true)
+			expect(data.Ammo).to.equal(30)
+			expect(data.ReserveAmmo).to.equal(132)
+			expect(data.Reloading).to.equal(false)
+			expect(data.ReloadEndsAt).to.equal(0)
+		end)
+
+		it("loads a partial magazine when reserve ammo is low", function()
+			local data = freshData(12, 5)
+			local operation = ReloadLogic.start(data, rifle, 100)
+
+			expect(ReloadLogic.complete(data, operation, rifle)).to.equal(true)
+			expect(data.Ammo).to.equal(17)
+			expect(data.ReserveAmmo).to.equal(0)
+		end)
+
+		it("rejects completion after elimination", function()
+			local data = freshData(12)
+			local operation = ReloadLogic.start(data, rifle, 100)
+			data.Eliminated = true
+
+			expect(ReloadLogic.complete(data, operation, rifle)).to.equal(false)
+			expect(data.Ammo).to.equal(12)
+		end)
+
+		it("rejects stale tokens and weapon changes", function()
+			local staleData = freshData(12)
+			local staleOperation = ReloadLogic.start(staleData, rifle, 100)
+			staleData.ReloadToken = staleData.ReloadToken + 1
+			expect(ReloadLogic.complete(staleData, staleOperation, rifle)).to.equal(false)
+
+			local changedData = freshData(12)
+			local changedOperation = ReloadLogic.start(changedData, rifle, 100)
+			changedData.Weapon = "Wraith Scout"
+			expect(ReloadLogic.complete(changedData, changedOperation, rifle)).to.equal(false)
+		end)
+	end)
+
+	describe("cancel", function()
+		it("invalidates the operation without changing ammo", function()
+			local data = freshData(12)
+			local operation = ReloadLogic.start(data, rifle, 100)
+
+			expect(ReloadLogic.cancel(data)).to.equal(true)
+			expect(data.Ammo).to.equal(12)
+			expect(data.Reloading).to.equal(false)
+			expect(ReloadLogic.complete(data, operation, rifle)).to.equal(false)
+		end)
+
+		it("returns false while idle but still invalidates stale tokens", function()
+			local data = freshData(12)
+			local token = data.ReloadToken
+
+			expect(ReloadLogic.cancel(data)).to.equal(false)
+			expect(data.ReloadToken).to.equal(token + 1)
+		end)
+
+		it("keeps an old operation invalid after a new reload starts", function()
+			local data = freshData(12)
+			local oldOperation = ReloadLogic.start(data, rifle, 100)
+			ReloadLogic.cancel(data)
+			local newOperation = ReloadLogic.start(data, rifle, 200)
+
+			expect(ReloadLogic.complete(data, oldOperation, rifle)).to.equal(false)
+			expect(ReloadLogic.complete(data, newOperation, rifle)).to.equal(true)
+		end)
+	end)
+end

--- a/src/ServerScriptService/TrainingService.lua
+++ b/src/ServerScriptService/TrainingService.lua
@@ -117,6 +117,9 @@ local function tryExitTraining(player, source)
 		return
 	end
 
+	local mm = _G.MatchManager
+	if mm then mm.cancelReload(player) end
+
 	-- Destroy equipped Tool before teleport — lobby is gun-less per #38.
 	local char = player.Character
 	if char then
@@ -146,11 +149,14 @@ events:WaitForChild("SelectTrainingWeapon").OnServerEvent:Connect(function(playe
 	end
 	local data = mm.getPlayerData(player)
 	if data then
+		mm.cancelReload(player)
 		data.Weapon = weaponName
 		data.Eliminated = false
 		local cfg = GameConfig.WEAPONS[weaponName]
-		data.Ammo = (cfg and cfg.MagSize) or data.Ammo
-		events.AmmoUpdate:FireClient(player, data.Ammo, (cfg and cfg.MagSize) or data.Ammo)
+		local magSize = (cfg and cfg.MagSize) or 0
+		data.Ammo = magSize
+		data.ReserveAmmo = magSize * GameConfig.STARTING_RESERVE_MAGAZINES
+		mm.syncAmmoState(player)
 	end
 	mm.attachWeapon(player, weaponName)
 	events.EquipWeapon:FireClient(player, weaponName)

--- a/src/ServerStorage/ReloadLogic.lua
+++ b/src/ServerStorage/ReloadLogic.lua
@@ -1,0 +1,75 @@
+-- ReloadLogic.lua (ServerStorage ModuleScript)
+-- Side-effect-free reload state transitions shared by MatchManager and TestEZ.
+
+local ReloadLogic = {}
+
+function ReloadLogic.addReserve(data, config, amount, maxReserveMagazines)
+	if type(data) ~= "table" or type(config) ~= "table" then return 0 end
+	if type(amount) ~= "number" or amount <= 0 then return 0 end
+	if type(maxReserveMagazines) ~= "number" or maxReserveMagazines <= 0 then return 0 end
+	if type(config.MagSize) ~= "number" or config.MagSize <= 0 then return 0 end
+
+	local reserveCap = config.MagSize * maxReserveMagazines
+	local previousReserve = math.clamp(data.ReserveAmmo or 0, 0, reserveCap)
+	data.ReserveAmmo = math.min(reserveCap, previousReserve + amount)
+	return data.ReserveAmmo - previousReserve
+end
+
+function ReloadLogic.canStart(data, config)
+	if type(data) ~= "table" or type(config) ~= "table" then return false end
+	if data.Eliminated or data.Reloading then return false end
+	if config.Type == "Knife" then return false end
+	if type(data.Ammo) ~= "number" then return false end
+	if type(data.ReserveAmmo) ~= "number" or data.ReserveAmmo <= 0 then return false end
+	if type(config.MagSize) ~= "number" or config.MagSize <= 0 then return false end
+	if type(config.ReloadTime) ~= "number" or config.ReloadTime <= 0 then return false end
+	return data.Ammo < config.MagSize
+end
+
+function ReloadLogic.start(data, config, now)
+	if not ReloadLogic.canStart(data, config) then return nil end
+
+	local token = (data.ReloadToken or 0) + 1
+	local duration = config.ReloadTime
+	data.ReloadToken = token
+	data.Reloading = true
+	data.ReloadEndsAt = now + duration
+
+	return {
+		Token = token,
+		Weapon = data.Weapon,
+		Duration = duration,
+		EndsAt = data.ReloadEndsAt,
+	}
+end
+
+function ReloadLogic.cancel(data)
+	if type(data) ~= "table" then return false end
+
+	local wasReloading = data.Reloading == true
+	data.ReloadToken = (data.ReloadToken or 0) + 1
+	data.Reloading = false
+	data.ReloadEndsAt = 0
+	return wasReloading
+end
+
+function ReloadLogic.complete(data, operation, config)
+	if type(data) ~= "table" or type(operation) ~= "table" or type(config) ~= "table" then
+		return false
+	end
+	if data.Eliminated or not data.Reloading then return false end
+	if data.ReloadToken ~= operation.Token then return false end
+	if data.Weapon ~= operation.Weapon then return false end
+	if type(config.MagSize) ~= "number" or config.MagSize <= 0 then return false end
+
+	local missingRounds = math.max(0, config.MagSize - data.Ammo)
+	local reserveAmmo = math.max(0, data.ReserveAmmo or 0)
+	local loadedRounds = math.min(missingRounds, reserveAmmo)
+	data.Ammo = data.Ammo + loadedRounds
+	data.ReserveAmmo = reserveAmmo - loadedRounds
+	data.Reloading = false
+	data.ReloadEndsAt = 0
+	return true
+end
+
+return ReloadLogic

--- a/src/StarterPlayerScripts/HUDController.lua
+++ b/src/StarterPlayerScripts/HUDController.lua
@@ -6,6 +6,7 @@
 
 local Players = game:GetService("Players")
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local TweenService = game:GetService("TweenService")
 
 local player = Players.LocalPlayer
 local events = ReplicatedStorage:WaitForChild("GameEvents")
@@ -65,7 +66,7 @@ ammoLabel.Position = UDim2.new(1, -170, 1, -60)
 ammoLabel.BackgroundColor3 = Color3.fromRGB(30, 30, 35)
 ammoLabel.BackgroundTransparency = 0.3
 ammoLabel.BorderSizePixel = 0
-ammoLabel.Text = "AMMO: 30"
+ammoLabel.Text = "AMMO: -- / --"
 ammoLabel.TextColor3 = Color3.fromRGB(255, 200, 50)
 ammoLabel.TextScaled = true
 ammoLabel.Font = Enum.Font.GothamBold
@@ -74,6 +75,48 @@ ammoLabel.Parent = screenGui
 local ammoCorner = Instance.new("UICorner")
 ammoCorner.CornerRadius = UDim.new(0, 6)
 ammoCorner.Parent = ammoLabel
+
+local reloadFrame = Instance.new("Frame")
+reloadFrame.Name = "ReloadFrame"
+reloadFrame.Size = UDim2.new(0, 150, 0, 28)
+reloadFrame.Position = UDim2.new(1, -170, 1, -96)
+reloadFrame.BackgroundColor3 = Color3.fromRGB(30, 30, 35)
+reloadFrame.BackgroundTransparency = 0.15
+reloadFrame.BorderSizePixel = 0
+reloadFrame.Visible = false
+reloadFrame.Parent = screenGui
+
+local reloadCorner = Instance.new("UICorner")
+reloadCorner.CornerRadius = UDim.new(0, 6)
+reloadCorner.Parent = reloadFrame
+
+local reloadLabel = Instance.new("TextLabel")
+reloadLabel.Name = "ReloadLabel"
+reloadLabel.Size = UDim2.new(1, -8, 0, 18)
+reloadLabel.Position = UDim2.new(0, 4, 0, 1)
+reloadLabel.BackgroundTransparency = 1
+reloadLabel.Text = "RELOADING..."
+reloadLabel.TextColor3 = Color3.fromRGB(255, 200, 50)
+reloadLabel.TextScaled = true
+reloadLabel.Font = Enum.Font.GothamBold
+reloadLabel.Parent = reloadFrame
+
+local reloadBarBack = Instance.new("Frame")
+reloadBarBack.Name = "ReloadBarBack"
+reloadBarBack.Size = UDim2.new(1, -8, 0, 5)
+reloadBarBack.Position = UDim2.new(0, 4, 1, -7)
+reloadBarBack.BackgroundColor3 = Color3.fromRGB(70, 70, 80)
+reloadBarBack.BorderSizePixel = 0
+reloadBarBack.Parent = reloadFrame
+
+local reloadBar = Instance.new("Frame")
+reloadBar.Name = "ReloadBar"
+reloadBar.Size = UDim2.new(0, 0, 1, 0)
+reloadBar.BackgroundColor3 = Color3.fromRGB(255, 70, 55)
+reloadBar.BorderSizePixel = 0
+reloadBar.Parent = reloadBarBack
+
+local reloadTween = nil
 
 -- === PHASE & TIMER ===
 local phaseLabel = Instance.new("TextLabel")
@@ -318,8 +361,29 @@ events:WaitForChild("HealthUpdate").OnClientEvent:Connect(function(hp, maxHP)
 	end
 end)
 
-events:WaitForChild("AmmoUpdate").OnClientEvent:Connect(function(current, max)
-	ammoLabel.Text = "AMMO: " .. current
+events:WaitForChild("AmmoUpdate").OnClientEvent:Connect(function(magazine, reserve)
+	ammoLabel.Text = string.format("AMMO: %d / %d", magazine, reserve)
+end)
+
+events:WaitForChild("ReloadStateChanged").OnClientEvent:Connect(function(active, duration)
+	if reloadTween then
+		reloadTween:Cancel()
+		reloadTween = nil
+	end
+
+	if active and duration > 0 then
+		reloadFrame.Visible = true
+		reloadBar.Size = UDim2.new(0, 0, 1, 0)
+		reloadTween = TweenService:Create(
+			reloadBar,
+			TweenInfo.new(duration, Enum.EasingStyle.Linear),
+			{ Size = UDim2.new(1, 0, 1, 0) }
+		)
+		reloadTween:Play()
+	else
+		reloadFrame.Visible = false
+		reloadBar.Size = UDim2.new(0, 0, 1, 0)
+	end
 end)
 
 events:WaitForChild("PhaseChanged").OnClientEvent:Connect(function(phase)

--- a/src/StarterPlayerScripts/WeaponClient.lua
+++ b/src/StarterPlayerScripts/WeaponClient.lua
@@ -7,16 +7,19 @@ local UserInputService = game:GetService("UserInputService")
 local RunService = game:GetService("RunService")
 local TweenService = game:GetService("TweenService")
 local Debris = game:GetService("Debris")
+local ContentProvider = game:GetService("ContentProvider")
 
 local player = Players.LocalPlayer
 local mouse = player:GetMouse()
 local camera = workspace.CurrentCamera
 
 local GameConfig = require(ReplicatedStorage:WaitForChild("GameConfig"))
+local R15Pose = require(ReplicatedStorage:WaitForChild("R15Pose"))
 local events = ReplicatedStorage:WaitForChild("GameEvents")
 
 local FireWeapon = events:WaitForChild("FireWeapon")
 local ReloadWeapon = events:WaitForChild("ReloadWeapon")
+local ReloadStateChanged = events:WaitForChild("ReloadStateChanged")
 
 -- Look up the equipped weapon Tool's Muzzle attachment on the local character.
 -- Returns nil if no Tool equipped or muzzle missing (e.g. first frame before
@@ -58,19 +61,201 @@ local currentWeapon = GameConfig.STARTER_WEAPONS[1]
 local canFire = true
 local isReloading = false
 local isFiring = false
+local currentAmmo = 0
+local reserveAmmo = 0
+local magSize = 0
+local reloadTrack = nil
+local reloadAnimation = nil
+local reloadPoseController = nil
+local reloadGeneration = 0
+local warnedReloadAnimationIds = {}
+local warnedUnsupportedReloadPose = false
+
+local RELOAD_POSE_PHASES = {
+	{ Fraction = 0, Pose = R15Pose.Poses.ReloadEject },
+	{ Fraction = 0.35, Pose = R15Pose.Poses.ReloadInsert },
+	{ Fraction = 0.7, Pose = R15Pose.Poses.ReloadRack },
+	{ Fraction = 0.9 },
+}
+
+local function stopReloadAnimation()
+	reloadGeneration += 1
+	if reloadTrack then
+		reloadTrack:Stop(0.1)
+		reloadTrack:Destroy()
+		reloadTrack = nil
+	end
+	if reloadAnimation then
+		reloadAnimation:Destroy()
+		reloadAnimation = nil
+	end
+	if reloadPoseController then
+		reloadPoseController:Destroy()
+		reloadPoseController = nil
+	end
+end
+
+local function warnReloadAnimationOnce(animationId, reason)
+	if warnedReloadAnimationIds[animationId] then return end
+	warnedReloadAnimationIds[animationId] = true
+	warn(("Reload animation %d unavailable (%s); using procedural fallback")
+		:format(animationId, reason))
+end
+
+task.spawn(function()
+	for _, animationId in pairs(GameConfig.RELOAD_ANIMATION_IDS or {}) do
+		if type(animationId) == "number" and animationId > 0 then
+			local animation = Instance.new("Animation")
+			animation.AnimationId = "rbxassetid://" .. animationId
+			local loaded, loadError = pcall(function()
+				ContentProvider:PreloadAsync({ animation })
+			end)
+			animation:Destroy()
+			if not loaded then
+				warnReloadAnimationOnce(animationId, tostring(loadError))
+			end
+		end
+	end
+end)
+
+local function playProceduralReload(duration, character, generation)
+	if reloadGeneration ~= generation then return end
+
+	local controller = R15Pose.new(character)
+	if not controller:IsSupported() then
+		controller:Destroy()
+		if not warnedUnsupportedReloadPose then
+			warnedUnsupportedReloadPose = true
+			warn("Procedural reload pose requires an R15 character with both shoulder joints")
+		end
+		return
+	end
+
+	reloadPoseController = controller
+	duration = math.max(duration, 0.1)
+	local blendTime = math.min(0.12, duration * 0.1)
+	controller:SetPose(RELOAD_POSE_PHASES[1].Pose, blendTime)
+
+	task.spawn(function()
+		local previousFraction = 0
+		for index = 2, #RELOAD_POSE_PHASES do
+			local phase = RELOAD_POSE_PHASES[index]
+			task.wait(duration * (phase.Fraction - previousFraction))
+			previousFraction = phase.Fraction
+
+			if reloadGeneration ~= generation or reloadPoseController ~= controller then
+				return
+			end
+			if phase.Pose then
+				controller:SetPose(phase.Pose, blendTime)
+			else
+				controller:Reset(blendTime)
+			end
+		end
+	end)
+end
+
+local function playReloadAnimation(duration, weaponName)
+	stopReloadAnimation()
+	local generation = reloadGeneration
+
+	local config = GameConfig.WEAPONS[weaponName]
+	local animationId = config
+		and GameConfig.RELOAD_ANIMATION_IDS
+		and GameConfig.RELOAD_ANIMATION_IDS[config.Type]
+
+	local character = player.Character
+	if not character then return end
+	local humanoid = character and character:FindFirstChildOfClass("Humanoid")
+	local animator = humanoid and humanoid:FindFirstChildOfClass("Animator")
+	if type(animationId) ~= "number" or animationId <= 0 or not animator then
+		playProceduralReload(duration, character, generation)
+		return
+	end
+
+	local animation = Instance.new("Animation")
+	animation.AnimationId = "rbxassetid://" .. animationId
+	local loaded, trackOrError = pcall(function()
+		return animator:LoadAnimation(animation)
+	end)
+	if not loaded then
+		animation:Destroy()
+		warnReloadAnimationOnce(animationId, tostring(trackOrError))
+		playProceduralReload(duration, character, generation)
+		return
+	end
+
+	local track = trackOrError
+	track.Priority = Enum.AnimationPriority.Action4
+	track.Looped = false
+
+	reloadAnimation = animation
+	reloadTrack = track
+	-- Start paused so asset-loading latency does not consume the reload clip.
+	track:Play(0.1, 1, 0)
+
+	-- Animation length can be zero until the asset finishes loading. Wait a
+	-- bounded number of frames, then fit the clip to the authoritative duration.
+	task.spawn(function()
+		local startedAt = os.clock()
+		for _ = 1, 60 do
+			if reloadGeneration ~= generation or reloadTrack ~= track or track.Length > 0 then
+				break
+			end
+			RunService.Heartbeat:Wait()
+		end
+		if reloadGeneration ~= generation or reloadTrack ~= track then return end
+
+		if track.Length > 0 and duration > 0 then
+			track:AdjustSpeed(track.Length / duration)
+			return
+		end
+
+		track:Stop(0.05)
+		track:Destroy()
+		reloadTrack = nil
+		if reloadAnimation == animation then
+			animation:Destroy()
+			reloadAnimation = nil
+		end
+		warnReloadAnimationOnce(animationId, "asset did not load within 60 frames")
+		playProceduralReload(
+			math.max(duration - (os.clock() - startedAt), 0.1),
+			character,
+			generation
+		)
+	end)
+end
+
+local function setReloadState(active, duration, weaponName)
+	isReloading = active == true
+	canFire = not isReloading
+	if isReloading then
+		playReloadAnimation(duration or 0, weaponName or currentWeapon)
+	else
+		stopReloadAnimation()
+	end
+end
 
 -- Listen for weapon equip
 events:WaitForChild("EquipWeapon").OnClientEvent:Connect(function(weaponName)
 	if GameConfig.WEAPONS[weaponName] then
+		setReloadState(false, 0, weaponName)
 		currentWeapon = weaponName
 		canFire = true
-		isReloading = false
 	end
 end)
 
-events:WaitForChild("ReloadComplete").OnClientEvent:Connect(function()
-	isReloading = false
-	canFire = true
+ReloadStateChanged.OnClientEvent:Connect(setReloadState)
+
+events:WaitForChild("AmmoUpdate").OnClientEvent:Connect(function(magazine, reserve, maximum)
+	currentAmmo = magazine
+	reserveAmmo = reserve
+	magSize = maximum
+end)
+
+player.CharacterAdded:Connect(function()
+	setReloadState(false, 0, currentWeapon)
 end)
 
 local function fireWeapon()
@@ -78,6 +263,7 @@ local function fireWeapon()
 
 	local config = GameConfig.WEAPONS[currentWeapon]
 	if not config then return end
+	if config.Type ~= "Knife" and magSize > 0 and currentAmmo <= 0 then return end
 
 	local character = player.Character
 	if not character then return end
@@ -119,13 +305,13 @@ local function fireWeapon()
 		-- Melee: short range check
 		FireWeapon:FireServer(origin, direction, currentWeapon)
 		task.delay(config.AttackRate, function()
-			canFire = true
+			if not isReloading then canFire = true end
 		end)
 	else
 		-- Ranged weapon
 		FireWeapon:FireServer(origin, direction, currentWeapon)
 		task.delay(config.FireRate, function()
-			canFire = true
+			if not isReloading then canFire = true end
 		end)
 	end
 end
@@ -140,7 +326,9 @@ UserInputService.InputBegan:Connect(function(input, processed)
 	end
 
 	if input.KeyCode == Enum.KeyCode.R then
-		if not isReloading then
+		if not isReloading and reserveAmmo > 0 and currentAmmo < magSize then
+			-- Block locally while waiting for the server's authoritative state
+			-- response. A rejected request receives ReloadStateChanged(false).
 			isReloading = true
 			canFire = false
 			ReloadWeapon:FireServer()

--- a/workloads/01-map-builder.yaml
+++ b/workloads/01-map-builder.yaml
@@ -1,7 +1,11 @@
 name: MapBuilder
 owner: claude-code
 priority: P0-prototype
-status: ✅ DONE (Sprint 1)
+status: ⚠️ FUNCTIONAL (core map complete; issue #55 industrial bunker hub parity open)
+current_state:
+  functional: "Lobby, StartMatchPad, arena, spectator area, and remote training arena are implemented."
+  visual_baseline: "FINAL STRIKE banner, Gun Shop pedestal, Training portal, and Classic Teams panel exist."
+  open_issue: "#55 still requires the full three-zone bunker layout, interactive shop display, Crisis entrance, and polish."
 stages:
   - define: 地圖結構設計 (Last Zone)
   - implement: 大廳 + 啟動台
@@ -10,11 +14,12 @@ stages:
   - implement: 燈光氛圍 (夜間/紅光/霧氣/Bloom)
   - verify: 進入 Studio → Play → 大廳走動 → 踩啟動台傳送
 success_criteria:
-  - 大廳有 FINAL STRIKE 標題牌
+  - 大廳有 FINAL STRIKE 標題牌與基礎功能分區
   - 啟動台可觸發（1人測試）
   - 競技場有 12+ 掩體
   - 觀戰區有 4 個練習靶
   - 夜間氛圍 + 紅色警示燈 + 霧氣
+  - "#55 的 90% 參考圖相似度仍待實際參考圖與分階段驗收"
 artifacts:
   - src/ServerScriptService/MapBuilder.lua
 recovery:

--- a/workloads/04-weapon-system.yaml
+++ b/workloads/04-weapon-system.yaml
@@ -1,7 +1,7 @@
 name: WeaponSystem
 owner: claude-code
 priority: P0-prototype
-status: ✅ DONE (Sprint 3 + Sprint 7 visual + Sprint 8b 30-weapon retune + Sniper headshot, 2026-05-03)
+status: "✅ IMPLEMENTED (#47 full-place E2E passed in 最後一擊 on 2026-07-12; awaiting PR)"
 sprint_8b_receipt: receipts/sprint-8b-200hp-rebalance.md
 
 # ============= Sprint 8b 計劃中的修改（CEO 決議 b 後重寫 2026-05-03） =============
@@ -138,23 +138,30 @@ sprint_8b_changes:
 stages:
   - define: 6 把虛構武器數據 (GameConfig)
   - implement: 射擊 Raycast + 傷害計算
-  - implement: 彈藥消耗 + 換彈
+  - implement: server-authoritative 手動/空彈自動換彈 + lifecycle cancellation
+  - implement: "magazine + reserve ammo（開場 5 個備用彈匣；pickup 累積至 15 個）"
   - implement: 客戶端輸入 + 自動射擊
   - implement: 武器 Tool + 第三人稱可見 mesh (Sprint 7)
   - implement: muzzle flash + raycast origin 從 Muzzle.WorldPosition (Sprint 7)
-  - verify: 每把武器射擊 + 傷害 + 換彈正常
+  - verify: "ReloadLogic 23 assertions + Studio clip/fallback/cancellation/reserve/client-input targeted checks"
+  - verify: "最後一擊 E2E: StartMatchPad 完整 phase lifecycle；manual 8/60→12/56；auto 1/12→12/0；partial 2/3→5/0；AmmoPickup 12/0→12/15"
+  - verify: "最後一擊 E2E: reload 中 respawn / elimination 均保留 8/60、清除 Reloading；respawn 重新掛槍，淘汰後無槍"
 success_criteria:
-  - 6 把武器可裝備可射擊
-  - Viper 25, Stinger 15, Phantom 30, Thunder 12×8, Wraith 90, Fang 40 (Sprint 8 重新平衡)
+  - 30 把武器可購買、裝備與射擊
+  - Common→Demon DPS 倍率收斂為 1.0/1.15/1.30/1.50/1.70/1.90
   - 全自動/半自動模式正確
-  - 彈藥耗盡需換彈
+  - 手動/空彈自動換彈依每把武器 ReloadTime，從 reserve 補彈並在期間由 server 拒絕射擊
+  - reserve 不足時只補剩餘子彈；Ammo pickup 增加 reserve 而不取消進行中的 reload
+  - Pistol/Rifle/Shotgun 用 owned R15 clip；其餘類型使用 non-physics procedural fallback
   - 玩家右手握槍可見、muzzle flash 從槍口出 (Sprint 7)
 artifacts:
   - src/ReplicatedStorage/GameConfig.lua (weapon data)
   - src/ServerScriptService/MatchManager.lua (fire handler)
   - src/StarterPlayerScripts/WeaponClient.lua
-  - src/ServerStorage/WeaponSystem.lua
+  - src/ReplicatedStorage/R15Pose.lua
+  - src/ServerStorage/ReloadLogic.lua
   - src/ServerStorage/WeaponMeshes.lua (Sprint 7)
+  - src/ServerScriptService/Tests/ReloadLogic.spec.lua
 recovery:
   - Raycast 穿牆 → FilterDescendantsInstances 排除自己
   - 傷害不觸發 → 檢查 RemoteEvent 是否在 GameEvents 建立

--- a/workloads/05-npc-system.yaml
+++ b/workloads/05-npc-system.yaml
@@ -1,7 +1,11 @@
 name: NPCSystem
 owner: claude-code
 priority: P0-prototype
-status: ✅ DONE (Sprint 3 + Sprint 7 R15 mesh + Sprint 8b HP×2 + 4-tier medkit drops, 2026-05-03)
+status: "✅ IMPLEMENTED (#36 full-place AI E2E passed in 最後一擊 on 2026-07-12; awaiting PR)"
+open_issues:
+  - "#36 remains open until the implementation PR lands."
+resolved_regressions:
+  - "#56 server-side LeftHand AlignPosition was disabled because it propelled character roots."
 sprint_8b_receipt: receipts/sprint-8b-200hp-rebalance.md
 
 # ============= Sprint 8 計劃中的修改 =============
@@ -66,14 +70,18 @@ stages:
   - implement: 被擊敗掉落戰利品
   - verify: NPC 巡邏 → 偵測玩家 → 追擊 → 攻擊 → 死亡掉寶
 success_criteria:
-  - Patrol 60HP, Armored 150HP, Elite 250HP (Sprint 8 將翻倍)
+  - Patrol 120HP, Armored 300HP, Elite 500HP
   - R15 character mesh + 自動 BodyColors + Animate LocalScript（內建）
   - 三種 NPC 衣裝差異化（Patrol 警衛帽+徽章 / Armored 戰術頭盔+背心 / Elite 兜帽+紅徽記+披風）
   - 偵測範圍內 Pathfinding 追擊，攻擊範圍內造成傷害
   - 死亡後根據 LootTable 掉落物品
+  - 攻擊時以 R15Pose 舉槍瞄準，射擊時 recoil，離開 Attack 時 reset
+  - "targeted Studio check: aim/fire transform 0° error、RootPart drift 0、WalkSpeed unchanged、no new instances"
+  - "最後一擊 E2E: 9 NPC spawn；近距 Patrol 進入 Attack/fire path；非零 joint pose 被觀察；physical constraint count = 0"
 artifacts:
   - src/ServerScriptService/NPCSystem.lua
   - src/ReplicatedStorage/GameConfig.lua (enemy data)
+  - src/ReplicatedStorage/R15Pose.lua (non-physics procedural upper-body pose)
 recovery:
   - NPC 不動 → 確認 HumanoidRootPart 存在 + Pathfinding agent params 對齊 R15 size
   - NPC 穿牆 → 用 PathfindingService 而非直接 MoveTo (Sprint 6 lesson)

--- a/workloads/15-fps-viewmodel.yaml
+++ b/workloads/15-fps-viewmodel.yaml
@@ -1,7 +1,7 @@
 name: FPSViewmodel
 owner: claude-code
 priority: P1-polish
-status: ✅ DONE (Sprint 8 — commits 3db2349, 78c4b9f, ab5a601, Sprint 8a 補檔)
+status: "⚠️ PARTIAL (#39 two-hand hold remains open; #47 reload E2E passed 2026-07-12)"
 backfill_receipt: receipts/sprint-8-shop-economy-fps.md
 backfill_note: |
   此 contract 為 Sprint 8a 衛生補課產出。實際實作分散在 main 多個 commits：
@@ -17,8 +17,8 @@ purpose: |
   比賽中第一人稱（FPS）視角體驗：
   1. CameraController 鎖第一人稱 + 鎖定鼠標到中心（PvE/PvPWarning/PvP）；
      大廳 / 觀戰時釋放回三人稱 + 自由鼠標。
-  2. ViewmodelController 強制手臂可見（覆蓋 LockFirstPerson 預設隱藏）+
-     LeftHand IK 把左手 pin 到武器 Handle.LeftGrip attachment（雙手持槍）。
+  2. ViewmodelController 強制手臂可見（覆蓋 LockFirstPerson 預設隱藏）；
+     WeaponClient 播放已發布的 R15 reload animation，無匹配 clip 時使用程序化姿勢。
   3. crosshair-aligned aim：raycast 從 viewport center 出，bullet 對齊準心
      而非 muzzle 方向（修正 #5/6/7）。
 
@@ -62,18 +62,26 @@ viewmodel_arms:
   fix: "RenderStepped 強制 6 個 arm parts (Left/Right Upper/Lower/Hand) LocalTransparencyModifier=0"
 
 left_hand_ik:
-  trigger: "Tool 加入 character 時 (ChildAdded)"
-  setup_delay: "task.wait(0.1) 讓 server 的 grip weld 安頓再解析 attachment"
-  ik_config:
-    Type: Position
-    ChainRoot: LeftUpperArm
-    EndEffector: LeftHand
-    Target: tool.Handle.LeftGrip (Attachment)
-    Weight: 1.0
-    Priority: 1000  # 高 priority 防 jump animation override (#12)
-  teardown: "Tool removed 或新 Tool equipped → 重建 IKControl"
-  exempt_weapons: |
-    單手武器（Pistol/Knife）武器 mesh 不需要 LeftGrip attachment，IK 自動 skip。
+  state: disabled
+  reason: |
+    舊 server-side grip solver 會透過物理 constraint 拖動 HumanoidRootPart，
+    造成玩家與 NPC 漂移（#56）。ViewmodelController 目前只維持手臂可見。
+  open_issue: "#39 — non-propulsive two-hand hold pose"
+
+reload_animation:
+  authoritative_timing: "MatchManager 提供 ReloadTime；client clip 依該 duration 調速"
+  published_ids:
+    Pistol: 102338606855201
+    Rifle: 99673558497035
+    Shotgun: 70858423637669
+  exact_type_policy: "不把 Rifle clip 冒用到 SMG / Sniper / Minigun"
+  fallback: "R15Pose 依序混合 ReloadEject → ReloadInsert → ReloadRack；不建立 physics constraint"
+  cancellation: "death / respawn / equip change / training exit / server reject 會停止 track 並銷毀 pose controller"
+  reserve_ammo: "HUD 顯示 magazine / reserve；pickup 進 reserve，不中斷當前 reload"
+  full_place_e2e_2026_07_12:
+    place: "最後一擊"
+    input: "實際 mouse click 與 R key"
+    evidence: "Pistol clip 102338606855201 播放；HUD progress 可見；manual/auto/partial reload、reserve pickup、respawn/elimination cancellation 均與 server state 一致"
 
 crosshair_aligned_aim:
   problem: |
@@ -86,17 +94,17 @@ crosshair_aligned_aim:
 
 artifacts:
   - src/StarterPlayerScripts/CameraController.lua  (130 行 — 主控)
-  - src/StarterPlayerScripts/ViewmodelController.lua  (94 行 — arms 可見 + LeftHand IK)
-  - src/StarterPlayerScripts/WeaponClient.lua  (修正 fire origin 至 camera center)
+  - src/StarterPlayerScripts/ViewmodelController.lua  (arms 可見)
+  - src/StarterPlayerScripts/WeaponClient.lua  (crosshair aim + reload animation/fallback)
+  - src/ReplicatedStorage/R15Pose.lua  (non-physical upper-body pose controller)
   - src/StarterPlayerScripts/HUDController.lua  (crosshair ScreenGui FinalStrikeCrosshair)
   - src/ServerScriptService/MatchManager.lua  (FireWeapon handler 接收 client crosshair-aligned direction)
 
 success_criteria:
   - "比賽中鎖第一人稱，玩家看到自己的手 + 武器"
-  - "雙手武器（Rifle/SMG/Sniper/Shotgun）左手 IK 抓在 LeftGrip"
-  - "Pistol/Knife 不啟動 IK（沒 LeftGrip attachment）"
-  - "Tool 切換時 IK 立即重建，不殘留前一把武器的 IK"
-  - "Jump 時 IK Priority 1000 蓋住 jump animation 的 LeftArm 軌道（#12）"
+  - "Pistol / Rifle / Shotgun 使用對應、由 Final Strike owner 發布的 R15 reload clip"
+  - "SMG / Sniper / Minigun 使用程序化 reload fallback，不冒用錯誤武器 clip"
+  - "reload 取消或換槍時不殘留 AnimationTrack / R15Pose task"
   - "Shop / Daily Quest UI 開啟時，鼠標釋放可點 UI 按鈕"
   - "UI 關閉後恢復 LockCenter（在比賽中）"
   - "被淘汰玩家切回三人稱觀戰（#11）"
@@ -106,14 +114,15 @@ success_criteria:
 recovery:
   - "鼠標卡 LockCenter 點不到 UI → releaseEnforceUntil 機制 / interactive_uis_set 是否註冊"
   - "手不見 → ViewmodelController RenderStepped LocalTransparencyModifier 強制"
-  - "雙手沒 IK → tool.Handle.LeftGrip attachment 是否存在；task.wait(0.1) 延遲足夠"
-  - "Jump 時手脫離武器 → IK Priority 是否 1000"
+  - "reload clip 不播放 → 檢查 GameConfig ID ownership；client 會預載，60 frames 仍未 ready 才切 fallback"
+  - "reload pose 殘留 → 檢查 ReloadStateChanged(false) 與 reloadGeneration cancellation"
   - "Bullet 不對齊 crosshair → WeaponClient raycast origin 是否改成 camera center"
 
 # ============= 已知限制 / Sprint 8b+ 候選 =============
 known_limitations:
   - "muzzle flash 仍 client-only（Sprint 7 lesson）— 跨玩家可見要 server-side flash event"
   - "Crosshair 是 4-segment open-center（commit d054043 CEO spec），未對應稀有度顏色"
+  - "一般持槍時的非物理雙手 pose 尚未接回；#39 保持 open"
 
 # ============= 依賴 =============
 dependencies:


### PR DESCRIPTION
## Summary
- add server-authoritative manual and empty-mag reload with magazine/reserve ammo, partial reloads, lifecycle cancellation, and HUD progress
- use Final Strike-owned Pistol/Rifle/Shotgun R15 reload clips with procedural fallbacks for unmatched weapon types
- add non-physical `R15Pose` NPC aim/fire/recoil transitions without root constraints
- reconcile README, TODOs, and workload contracts with the implemented behavior and current issue state

## Validation
- ran the real `最後一擊` place through Lobby → PvE → PvPWarning → PvP → MatchEnd → Lobby
- verified manual `8/60 → 12/56`, automatic `1/12 → 12/0`, partial `2/3 → 5/0`, and AmmoPickup `12/0 → 12/15`
- verified reload cancellation during respawn and elimination, including correct Tool/HUD state
- verified Pistol animation `102338606855201`, reload HUD progress, nine NPC spawns, NPC Attack/fire poses, and zero physical constraints
- compiled all ten changed runtime scripts in Studio and parsed all changed YAML contracts

Closes #36
Closes #47

#39 remains open for the normal two-hand hold pose. #55 remains blocked until the actual lobby reference image is available.