### PR TITLE
Add safe two-hand grip and FPS ViewModel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,8 +162,8 @@ _隨開發進度持續更新_
 
 ### Sprint 8 補充（補檔 2026-05-03，詳見 receipts/sprint-8-shop-economy-fps.md）
 - **武器 raycast origin 改用 camera viewport center 而非 Muzzle.WorldPosition**：Sprint 7 從 muzzle 發射雖然「視覺合理」但與螢幕中心 crosshair 不對齊（muzzle 在槍身右側 → bullet 飄）。Sprint 8 改回 camera center + crosshair-aligned direction（推翻 Sprint 7 的「camera→muzzle」決定，issue #5/6/7）
-- **FPS LockFirstPerson 隱藏所有 body parts**：CameraScript 設 `LocalTransparencyModifier=1` 在所有 body parts 上 → 玩家看不到自己的手。每 frame `RenderStepped` 強制 6 個 arm parts (Left/Right Upper/Lower/Hand) `LocalTransparencyModifier=0` 才能可見
-- **LeftHand IK 必須 Priority 1000**：默認 priority 會被 jump animation 的 LeftArm track 蓋掉，玩家跳起時左手會脫離武器（issue #12）
+- **FPS 用 local camera ViewModel，不顯示真實手臂**：`FirstPersonViewmodel` 在 `CurrentCamera` 下 clone 左右 R15 Hand + Tool mesh，以 Motor6D 每個 `RenderStepped` 跟 camera；真實本機手臂/Tool 只用 `LocalTransparencyModifier=1` 隱藏，其他玩家仍看到第三人稱角色
+- **第三人稱雙手姿勢必須 persistent、non-physical**：`ViewmodelController` 在每個 client 用 `R15Pose.SetPersistentPose(TwoHandHold)` 維持 jump/freefall 姿勢；reload 期間由 server-owned `FinalStrikeReloading` 暫停。不可恢復 AlignPosition/IK rigid pin，否則會重現 #56 RootPart 漂移/彈飛
 - **MouseBehavior LockCenter 過渡時要強制 Default 一段時間**：`CameraMode = Classic` 後，內建 CameraScript 仍會延續 LockCenter 數 frames。退出第一人稱時設 `releaseEnforceUntil = tick() + 1.0`，`RenderStepped` 在這 1 秒內持續強制 Default，否則鼠標被搶回 LockCenter，shop / 觀戰點不到 UI（issue #14, #15）
 - **Interactive UI 開啟時必須臨時釋放 MouseBehavior**：LockCenter 會吞掉 click，shop / daily-quest UI 開啟期間要切回 Default 才能點 UI 按鈕。連 GUI Enabled signal 偵測比監聽整個 InputService 更便宜
 - **Crosshair 必須在自己的 ScreenGui**：HUD 主 ScreenGui 隱藏時 crosshair 也跟著隱藏 → 不該。隔離成獨立 ScreenGui (`FinalStrikeCrosshair`) 才能獨立控制（reviewer #13 要求）

--- a/receipts/sprint-8-shop-economy-fps.md
+++ b/receipts/sprint-8-shop-economy-fps.md
@@ -28,13 +28,13 @@ Backfilled by: claude-code (Sprint 8a 衛生補課)
 
 ### FPS 視角（commits 3db2349, 78c4b9f, ab5a601, 9829d65, 6997184）
 - [x] CameraController（130 行）— PvE/PvPWarning/PvP 鎖第一人稱 + LockCenter；大廳 / Match End / 觀戰 釋放
-- [x] ViewmodelController（94 行）— 強制 6 個 arm parts 可見 + LeftHand IK pin 到 Tool.Handle.LeftGrip
+- [x] ViewmodelController / FirstPersonViewmodel — non-physical 第三人稱雙手 pose + local camera Motor6D 雙手武器 rig
 - [x] crosshair 4-segment open-center 完成（commit d054043 — CEO spec）
 - [x] crosshair 在自己的 ScreenGui FinalStrikeCrosshair 隔離（reviewer #13 要求）
 - [x] crosshair 在大廳 / 觀戰 / UI 開啟時隱藏（commit 9829d65）
 - [x] 觀戰 camera fix（commit 78c4b9f — 被淘汰玩家切第三人稱）
 - [x] right-click work in third-person（commit ab5a601 — release MouseBehavior 機制）
-- [x] IK Priority 1000 防 jump 時手脫離武器（commit 78c4b9f — fix #12）
+- [x] #39 以 persistent non-physical R15 pose 取代舊 IK priority，jump/freefall 不脫手且不產生 #56 physics drift
 - [x] IK survives jump（同上）
 
 ### NPC 武器與射擊視覺（commit 253863f, 6236dc1）

--- a/src/ReplicatedStorage/R15Pose.lua
+++ b/src/ReplicatedStorage/R15Pose.lua
@@ -43,11 +43,11 @@ end
 
 R15Pose.Poses = {
 	TwoHandHold = {
-		RightShoulder = angles(-55, 0, 10),
-		RightElbow = angles(-25, 0, 0),
-		LeftShoulder = angles(-65, -10, -25),
-		LeftElbow = angles(-55, 0, 0),
-		LeftWrist = angles(0, 15, 0),
+		RightShoulder = angles(-6, -23, -9),
+		RightElbow = angles(1, -25, -54),
+		LeftShoulder = angles(64, -65, 0),
+		LeftElbow = angles(60, 0, 59),
+		LeftWrist = angles(46, 3, -65),
 	},
 	NPCAim = {
 		RightShoulder = angles(-75, 0, 5),
@@ -94,6 +94,7 @@ function R15Pose.new(character)
 		Target = {},
 		BlendSpeed = math.huge,
 		BlendRemaining = 0,
+		Persistent = false,
 		Active = false,
 		Destroyed = false,
 	}, Controller)
@@ -130,7 +131,7 @@ function R15Pose.new(character)
 			end
 		end
 		self.BlendRemaining = math.max(0, self.BlendRemaining - dt)
-		self.Active = self.BlendRemaining > 0
+		self.Active = self.Persistent or self.BlendRemaining > 0
 	end)
 
 	self.AncestryConnection = character.AncestryChanged:Connect(function(_, parent)
@@ -144,13 +145,35 @@ function Controller:IsSupported()
 	return self.Joints.RightShoulder ~= nil and self.Joints.LeftShoulder ~= nil
 end
 
-function Controller:SetPose(pose, blendTime)
+local function setPoseTarget(self, pose, blendTime)
 	if self.Destroyed then return end
 	self.BlendRemaining = math.max(blendTime or 0, 0)
 	self.BlendSpeed = self.BlendRemaining > 0 and (5 / self.BlendRemaining) or math.huge
 	self.Active = true
 	for name in pairs(self.Joints) do
 		self.Target[name] = pose[name] or CFrame.new()
+	end
+end
+
+function Controller:SetPose(pose, blendTime)
+	self.Persistent = false
+	setPoseTarget(self, pose, blendTime)
+end
+
+function Controller:SetPersistentPose(pose, blendTime)
+	self.Persistent = true
+	setPoseTarget(self, pose, blendTime)
+end
+
+function Controller:Stop()
+	if self.Destroyed then return end
+	self.Persistent = false
+	self.Active = false
+	self.BlendRemaining = 0
+	for name, joint in pairs(self.Joints) do
+		self.Current[name] = CFrame.new()
+		self.Target[name] = CFrame.new()
+		if joint.Parent then joint.Transform = CFrame.new() end
 	end
 end
 

--- a/src/ReplicatedStorage/ViewmodelState.lua
+++ b/src/ReplicatedStorage/ViewmodelState.lua
@@ -1,0 +1,28 @@
+-- ViewmodelState.lua (ReplicatedStorage ModuleScript)
+-- Local-only coordination between WeaponClient and FirstPersonViewmodel.
+
+local recoilEvent = Instance.new("BindableEvent")
+local activeMuzzle = nil
+
+local ViewmodelState = {}
+
+function ViewmodelState.EmitRecoil(weaponType)
+	recoilEvent:Fire(weaponType)
+end
+
+function ViewmodelState.OnRecoil(callback)
+	return recoilEvent.Event:Connect(callback)
+end
+
+function ViewmodelState.SetActiveMuzzle(muzzle)
+	activeMuzzle = muzzle
+end
+
+function ViewmodelState.GetActiveMuzzle()
+	if activeMuzzle and activeMuzzle.Parent then
+		return activeMuzzle
+	end
+	return nil
+end
+
+return ViewmodelState

--- a/src/ServerScriptService/MatchManager.lua
+++ b/src/ServerScriptService/MatchManager.lua
@@ -18,6 +18,7 @@ local PlayerEliminated = events:WaitForChild("PlayerEliminated")
 local KillFeed = events:WaitForChild("KillFeed")
 local AmmoUpdate = events:WaitForChild("AmmoUpdate")
 local ReloadStateChanged = events:WaitForChild("ReloadStateChanged")
+local RELOAD_POSE_ATTRIBUTE = "FinalStrikeReloading"
 
 -- Per-shot [Fire] debug logging. Auto weapons fire ~12 shots/sec and shotguns
 -- log per pellet, so this is OFF by default to avoid flooding the console
@@ -48,6 +49,12 @@ local function pushAmmoState(player, data)
 	local config = GameConfig.WEAPONS[data.Weapon]
 	local magSize = (config and config.MagSize) or 0
 	AmmoUpdate:FireClient(player, data.Ammo or 0, data.ReserveAmmo or 0, magSize)
+end
+
+local function setReloadPoseState(player, active)
+	if player.Parent == Players then
+		player:SetAttribute(RELOAD_POSE_ATTRIBUTE, active == true)
+	end
 end
 
 -- Reward helper: routes through CurrencyService (which enforces per-match caps)
@@ -118,6 +125,7 @@ function MatchManager.initPlayerData(player)
 	local healthUpdate = events:WaitForChild("HealthUpdate")
 	healthUpdate:FireClient(player, GameConfig.MAX_HP, GameConfig.MAX_HP)
 	pushAmmoState(player, playerData[player])
+	setReloadPoseState(player, false)
 	ReloadStateChanged:FireClient(player, false, 0, equipped)
 	events:WaitForChild("EquipWeapon"):FireClient(player, equipped)
 end
@@ -129,17 +137,23 @@ end
 
 local function pushReloadState(player, active, duration, weaponName)
 	if player.Parent == Players then
+		setReloadPoseState(player, active)
 		ReloadStateChanged:FireClient(player, active, duration or 0, weaponName)
 	end
 end
 
 function MatchManager.cancelReload(player)
 	local data = playerData[player]
-	if not data then return false end
+	if not data then
+		setReloadPoseState(player, false)
+		return false
+	end
 
 	local wasReloading = ReloadLogic.cancel(data)
 	if wasReloading then
 		pushReloadState(player, false, 0, data.Weapon)
+	else
+		setReloadPoseState(player, false)
 	end
 	return wasReloading
 end

--- a/src/ServerStorage/WeaponMeshes.lua
+++ b/src/ServerStorage/WeaponMeshes.lua
@@ -196,10 +196,10 @@ local TYPE_TO_BUILDER = {
 }
 
 -- Local position of the LeftGrip attachment (relative to Handle) per weapon Type.
--- WeaponMeshes.attachLeftHandIK is still called server-side from MatchManager
--- and NPCSystem, but the off-hand solver is disabled for now (#56). The active
--- path only normalizes RightGrip orientation so guns do not point into the floor.
--- Nil entries (Pistol, Knife) mean "single-handed, no IK".
+-- ViewmodelController consumes these attachments on every client to select the
+-- non-physical TwoHandHold pose. The old server solver stays disabled (#56);
+-- attachLeftHandIK only normalizes RightGrip orientation. Nil entries (Pistol,
+-- Knife) mean "single-handed".
 --
 -- Avatar-Joint-Upgrade rigs have a hard reach limit on the left arm:
 -- shoulder→LeftHand-center fully extended ≈ 1.86 studs. With the old
@@ -238,8 +238,7 @@ function WeaponMeshes.build(weaponName)
 	end
 	local model, handle = fn()
 
-	-- Add LeftGrip attachment for two-handed weapons so the server grip solver can
-	-- snap the character's LeftHand to it (visual: both hands gripping the gun).
+	-- Mark two-handed weapons for the client-side, non-physical hold pose.
 	local leftGripOffset = LEFT_GRIP_OFFSET[cfg.Type]
 	if leftGripOffset then
 		local leftGrip = Instance.new("Attachment")

--- a/src/ServerStorage/WeaponMeshes.lua
+++ b/src/ServerStorage/WeaponMeshes.lua
@@ -394,15 +394,10 @@ function WeaponMeshes.attachLeftHandIK(character, tool)
 	-- pin the hand 2.2 studs from the LeftGrip regardless of MaxForce (1k–50k
 	-- all measured the same gap). The rigid pin is the only path that closes
 	-- that distance, and it's also the only path that causes the drag.
-	-- Trade-off: ALL characters lose the two-hand grip visual — NPCs, other
-	-- players in third-person, AND the local player's first-person view of
-	-- their own arms. ViewmodelController only forces real character arms
-	-- visible in first-person (no separate cosmetic viewmodel rig), so when
-	-- the server IK is disabled the local view loses the off-hand pose too.
-	-- Accepted because the RootPart drift / NPC propulsion this caused was
-	-- gameplay-breaking. Re-enable when we have a non-propulsive grip
-	-- mechanism (custom animation, or an anchor-style pin that doesn't
-	-- close the kinematic chain).
+	-- Non-physical client systems now supply both visuals: ViewmodelController
+	-- writes third-person R15 joint transforms, while FirstPersonViewmodel owns
+	-- the camera-local hands and weapon. Keep the old physical implementation
+	-- below disabled so RootPart drift / NPC propulsion cannot return.
 	if true then return nil end
 	-- luacheck: ignore (rest kept for reference / future re-enable)
 

--- a/src/StarterPlayerScripts/FirstPersonViewmodel.lua
+++ b/src/StarterPlayerScripts/FirstPersonViewmodel.lua
@@ -1,0 +1,456 @@
+-- FirstPersonViewmodel.lua (StarterPlayerScripts)
+-- Local camera-space hands and weapon. Gameplay remains on the real Tool.
+
+local Players = game:GetService("Players")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local RunService = game:GetService("RunService")
+local UserInputService = game:GetService("UserInputService")
+
+local player = Players.LocalPlayer
+local GameConfig = require(ReplicatedStorage:WaitForChild("GameConfig"))
+local ViewmodelState = require(ReplicatedStorage:WaitForChild("ViewmodelState"))
+local ReloadStateChanged = ReplicatedStorage:WaitForChild("GameEvents")
+	:WaitForChild("ReloadStateChanged")
+
+local VIEWMODEL_NAME = "FinalStrikeViewModel"
+local VIEWMODEL_RENDER_STEP = "FinalStrikeViewModelRender"
+local WALL_CHECK_DISTANCE = 2.6
+local FIRST_PERSON_ENTER_DISTANCE = 0.6
+local FIRST_PERSON_EXIT_DISTANCE = 0.75
+local GOLD_COLOR = Color3.fromRGB(212, 175, 55)
+local VIEWMODEL_OFFSETS = {
+	Pistol = CFrame.new(0.65, -0.62, -2)
+		* CFrame.Angles(math.rad(-5), math.rad(8), 0),
+	SMG = CFrame.new(0.55, -0.7, -2.65)
+		* CFrame.Angles(math.rad(-4), math.rad(7), 0),
+	Rifle = CFrame.new(0.55, -0.72, -3.1)
+		* CFrame.Angles(math.rad(-4), math.rad(7), 0),
+	Shotgun = CFrame.new(0.55, -0.72, -3.2)
+		* CFrame.Angles(math.rad(-4), math.rad(7), 0),
+	Sniper = CFrame.new(0.55, -0.72, -3.25)
+		* CFrame.Angles(math.rad(-4), math.rad(7), 0),
+	Minigun = CFrame.new(0.55, -0.75, -3.25)
+		* CFrame.Angles(math.rad(-4), math.rad(7), 0),
+	Knife = CFrame.new(0.65, -0.65, -2)
+		* CFrame.Angles(math.rad(-5), math.rad(8), 0),
+}
+local DEFAULT_VIEWMODEL_OFFSET = VIEWMODEL_OFFSETS.Rifle
+local RIGHT_HAND_POSE = CFrame.new(0.12, -0.18, 0.08)
+	* CFrame.Angles(math.rad(-90), 0, math.rad(4))
+local LEFT_HAND_POSES = {
+	Pistol = CFrame.new(-0.25, -0.2, 0.12)
+		* CFrame.Angles(math.rad(-90), 0, math.rad(-18)),
+	Knife = CFrame.new(-0.42, -0.28, 0.2)
+		* CFrame.Angles(math.rad(-80), math.rad(-12), math.rad(-20)),
+}
+local DEFAULT_LEFT_HAND_POSE = CFrame.new(-0.08, 0.14, -1.28)
+	* CFrame.Angles(math.rad(-90), 0, 0)
+local ARM_PARTS = {
+	LeftUpperArm = true,
+	LeftLowerArm = true,
+	LeftHand = true,
+	RightUpperArm = true,
+	RightLowerArm = true,
+	RightHand = true,
+}
+local RECOIL_STRENGTH = {
+	Pistol = 1.0,
+	SMG = 0.55,
+	Rifle = 0.75,
+	Shotgun = 1.35,
+	Sniper = 1.6,
+	Minigun = 0.4,
+	Knife = 0.3,
+}
+
+local viewmodel = nil
+local sprintHeld = false
+local reloadActive = false
+local reloadStartedAt = 0
+local reloadDuration = 0
+
+local function expAlpha(speed, dt)
+	return 1 - math.exp(-speed * dt)
+end
+
+local function makeMotor(name, part0, part1, c0, c1, parent)
+	local motor = Instance.new("Motor6D")
+	motor.Name = name
+	motor.Part0 = part0
+	motor.Part1 = part1
+	motor.C0 = c0 or CFrame.new()
+	motor.C1 = c1 or CFrame.new()
+	motor.Parent = parent or part0
+	return motor
+end
+
+local function preparePart(part)
+	part.Anchored = false
+	part.CanCollide = false
+	part.CanTouch = false
+	part.CanQuery = false
+	part.Massless = true
+	part.CastShadow = false
+	part.LocalTransparencyModifier = 0
+end
+
+local function cloneLimb(source, name, scale)
+	if not source or not source:IsA("BasePart") then return nil end
+	local limb = source:Clone()
+	limb.Name = name
+	limb.Size = source.Size * scale
+	for _, descendant in ipairs(limb:GetDescendants()) do
+		if descendant:IsA("JointInstance")
+			or descendant:IsA("Constraint")
+			or descendant:IsA("Attachment")
+			or descendant:IsA("BaseScript")
+		then
+			descendant:Destroy()
+		end
+	end
+	preparePart(limb)
+	return limb
+end
+
+local function setRealPartsHidden(character, tool, hidden)
+	if character then
+		for partName in pairs(ARM_PARTS) do
+			local part = character:FindFirstChild(partName)
+			if part and part:IsA("BasePart") then
+				part.LocalTransparencyModifier = hidden and 1 or 0
+			end
+		end
+	end
+	if tool then
+		for _, descendant in ipairs(tool:GetDescendants()) do
+			if descendant:IsA("BasePart") then
+				descendant.LocalTransparencyModifier = hidden and 1 or 0
+			end
+		end
+	end
+end
+
+local function destroyViewmodel()
+	if not viewmodel then return end
+	setRealPartsHidden(viewmodel.Character, viewmodel.SourceTool, false)
+	ViewmodelState.SetActiveMuzzle(nil)
+	if viewmodel.Model then viewmodel.Model:Destroy() end
+	viewmodel = nil
+end
+
+local function convertWeaponWeldsToMotors(model)
+	for _, descendant in ipairs(model:GetDescendants()) do
+		if descendant:IsA("WeldConstraint") then
+			local part0 = descendant.Part0
+			local part1 = descendant.Part1
+			if part0 and part1 then
+				makeMotor(
+					"Viewmodel" .. part1.Name,
+					part0,
+					part1,
+					part0.CFrame:ToObjectSpace(part1.CFrame),
+					CFrame.new(),
+					part0
+				)
+			end
+			descendant:Destroy()
+		end
+	end
+end
+
+local function buildViewmodel(character, sourceTool)
+	destroyViewmodel()
+
+	local camera = workspace.CurrentCamera
+	local sourceHandle = sourceTool and sourceTool:FindFirstChild("Handle")
+	local sourceRightHand = character and character:FindFirstChild("RightHand")
+	local sourceLeftHand = character and character:FindFirstChild("LeftHand")
+	if not camera
+		or not sourceHandle
+		or not sourceRightHand
+		or not sourceLeftHand
+	then
+		return
+	end
+	local weaponConfig = GameConfig.WEAPONS[sourceTool.Name]
+	local weaponType = weaponConfig and weaponConfig.Type or "Rifle"
+	local viewmodelOffset = VIEWMODEL_OFFSETS[weaponType] or DEFAULT_VIEWMODEL_OFFSET
+	local leftHandPose = LEFT_HAND_POSES[weaponType] or DEFAULT_LEFT_HAND_POSE
+
+	local model = Instance.new("Model")
+	model.Name = VIEWMODEL_NAME
+	model:SetAttribute("SourceWeapon", sourceTool.Name)
+	model:SetAttribute("WeaponType", weaponType)
+	model:SetAttribute(
+		"PresentationName",
+		sourceTool.Name == "Viper Aurum" and "Golden Viper" or sourceTool.Name
+	)
+
+	local root = Instance.new("Part")
+	root.Name = "ViewmodelRoot"
+	root.Size = Vector3.new(0.1, 0.1, 0.1)
+	root.Transparency = 1
+	root.Anchored = true
+	root.CanCollide = false
+	root.CanTouch = false
+	root.CanQuery = false
+	root.CastShadow = false
+	root.Parent = model
+
+	local toolClone = sourceTool:Clone()
+	for _, child in ipairs(toolClone:GetChildren()) do
+		child.Parent = model
+	end
+	toolClone:Destroy()
+
+	local handle = model:FindFirstChild("Handle")
+	if not handle or not handle:IsA("BasePart") then
+		model:Destroy()
+		return
+	end
+	for _, descendant in ipairs(model:GetDescendants()) do
+		if descendant:IsA("BasePart") and descendant ~= root then
+			preparePart(descendant)
+			if sourceTool.Name == "Viper Aurum"
+				and descendant.Name ~= "Barrel"
+				and descendant.Material ~= Enum.Material.Neon
+			then
+				descendant.Color = GOLD_COLOR
+				descendant.Material = Enum.Material.Metal
+			end
+		end
+	end
+	convertWeaponWeldsToMotors(model)
+
+	local rightHand = cloneLimb(sourceRightHand, "RightHand", 0.55)
+	local leftHand = cloneLimb(sourceLeftHand, "LeftHand", 0.55)
+	if not rightHand or not leftHand then
+		model:Destroy()
+		return
+	end
+	rightHand.Parent = model
+	leftHand.Parent = model
+
+	local weaponMotor = makeMotor(
+		"WeaponMotor",
+		root,
+		handle,
+		viewmodelOffset,
+		CFrame.new(),
+		root
+	)
+	makeMotor(
+		"RightHandMotor",
+		handle,
+		rightHand,
+		RIGHT_HAND_POSE,
+		CFrame.new(),
+		handle
+	)
+	local leftHandMotor = makeMotor(
+		"LeftHandMotor",
+		handle,
+		leftHand,
+		leftHandPose,
+		CFrame.new(),
+		handle
+	)
+	model.PrimaryPart = root
+	model.Parent = camera
+	model:PivotTo(camera.CFrame)
+
+	local rayParams = RaycastParams.new()
+	rayParams.FilterType = Enum.RaycastFilterType.Exclude
+	rayParams.FilterDescendantsInstances = { character, model }
+
+	ViewmodelState.SetActiveMuzzle(handle:FindFirstChild("Muzzle"))
+	viewmodel = {
+		Model = model,
+		Root = root,
+		WeaponMotor = weaponMotor,
+		LeftHandMotor = leftHandMotor,
+		SourceTool = sourceTool,
+		Character = character,
+		Camera = camera,
+		Motion = CFrame.new(),
+		LeftHandMotion = CFrame.new(),
+		Sway = Vector2.new(),
+		BobTime = 0,
+		Recoil = 0,
+		RecoilVelocity = 0,
+		RayParams = rayParams,
+	}
+	setRealPartsHidden(character, sourceTool, true)
+end
+
+local function isFirstPerson(character)
+	local camera = workspace.CurrentCamera
+	local head = character and character:FindFirstChild("Head")
+	if not camera or not head then return false end
+	local distanceThreshold = viewmodel
+		and FIRST_PERSON_EXIT_DISTANCE
+		or FIRST_PERSON_ENTER_DISTANCE
+	return player.CameraMode == Enum.CameraMode.LockFirstPerson
+		or (camera.CFrame.Position - head.Position).Magnitude < distanceThreshold
+end
+
+local function getReloadMotion()
+	if not reloadActive or reloadDuration <= 0 then
+		return CFrame.new(), CFrame.new()
+	end
+
+	local progress = math.clamp((os.clock() - reloadStartedAt) / reloadDuration, 0, 1)
+	local lowered = CFrame.new(-0.18, -0.32, 0.22)
+		* CFrame.Angles(math.rad(22), math.rad(-18), math.rad(-12))
+	local rack = CFrame.new(0.12, -0.12, 0.12)
+		* CFrame.Angles(math.rad(-10), math.rad(12), math.rad(8))
+	local leftAway = CFrame.new(-0.35, -0.35, 0.15)
+		* CFrame.Angles(math.rad(25), 0, math.rad(-20))
+
+	if progress < 0.25 then
+		local alpha = progress / 0.25
+		return CFrame.new():Lerp(lowered, alpha), CFrame.new():Lerp(leftAway, alpha)
+	elseif progress < 0.75 then
+		local alpha = (progress - 0.25) / 0.5
+		return lowered:Lerp(rack, alpha), leftAway
+	end
+
+	local alpha = (progress - 0.75) / 0.25
+	return rack:Lerp(CFrame.new(), alpha), leftAway:Lerp(CFrame.new(), alpha)
+end
+
+local function updateViewmodel(dt)
+	local character = player.Character
+	local humanoid = character and character:FindFirstChildOfClass("Humanoid")
+	local sourceTool = character and character:FindFirstChildOfClass("Tool")
+	local active = character
+		and humanoid
+		and humanoid.Health > 0
+		and sourceTool
+		and isFirstPerson(character)
+
+	if not active then
+		destroyViewmodel()
+		return
+	end
+	if not viewmodel
+		or viewmodel.Character ~= character
+		or viewmodel.SourceTool ~= sourceTool
+		or viewmodel.Camera ~= workspace.CurrentCamera
+		or viewmodel.Model.Parent ~= workspace.CurrentCamera
+	then
+		buildViewmodel(character, sourceTool)
+	end
+	if not viewmodel then return end
+
+	local camera = workspace.CurrentCamera
+	viewmodel.Model:PivotTo(camera.CFrame)
+	setRealPartsHidden(character, sourceTool, true)
+
+	local moving = humanoid.MoveDirection.Magnitude > 0.1
+		and humanoid.FloorMaterial ~= Enum.Material.Air
+	local sprinting = sprintHeld and moving and not reloadActive
+	local now = os.clock()
+	local idle = CFrame.new(
+		math.sin(now * 1.3) * 0.012,
+		math.cos(now * 1.7) * 0.01,
+		0
+	) * CFrame.Angles(0, 0, math.sin(now * 1.1) * 0.004)
+
+	local bob = CFrame.new()
+	if moving then
+		viewmodel.BobTime += dt * (sprinting and 13 or 9)
+		bob = CFrame.new(
+			math.cos(viewmodel.BobTime) * (sprinting and 0.045 or 0.025),
+			math.abs(math.sin(viewmodel.BobTime)) * (sprinting and 0.055 or 0.032),
+			0
+		) * CFrame.Angles(
+			math.sin(viewmodel.BobTime) * 0.018,
+			0,
+			math.cos(viewmodel.BobTime) * 0.025
+		)
+	end
+
+	local sprintPose = sprinting
+		and (CFrame.new(0.28, -0.32, 0.18)
+			* CFrame.Angles(math.rad(-18), math.rad(28), math.rad(8)))
+		or CFrame.new()
+	local wallHit = workspace:Raycast(
+		camera.CFrame.Position,
+		camera.CFrame.LookVector * WALL_CHECK_DISTANCE,
+		viewmodel.RayParams
+	)
+	local wallAlpha = wallHit
+		and math.clamp(1 - (wallHit.Distance / WALL_CHECK_DISTANCE), 0, 1)
+		or 0
+	local wallPose = CFrame.new(0, -0.3 * wallAlpha, 1.8 * wallAlpha)
+		* CFrame.Angles(math.rad(-45 * wallAlpha), 0, 0)
+
+	local mouseDelta = UserInputService:GetMouseDelta()
+	local swayTarget = Vector2.new(
+		math.clamp(-mouseDelta.X * 0.0018, -0.05, 0.05),
+		math.clamp(-mouseDelta.Y * 0.0018, -0.05, 0.05)
+	)
+	viewmodel.Sway = viewmodel.Sway:Lerp(swayTarget, expAlpha(18, dt))
+	local sway = CFrame.Angles(viewmodel.Sway.Y, viewmodel.Sway.X, 0)
+
+	viewmodel.RecoilVelocity += -viewmodel.Recoil * 70 * dt
+	viewmodel.RecoilVelocity *= math.exp(-12 * dt)
+	viewmodel.Recoil += viewmodel.RecoilVelocity * dt
+	if math.abs(viewmodel.Recoil) < 0.0001
+		and math.abs(viewmodel.RecoilVelocity) < 0.0001
+	then
+		viewmodel.Recoil = 0
+		viewmodel.RecoilVelocity = 0
+	end
+	local recoil = CFrame.new(0, 0, viewmodel.Recoil * 0.1)
+		* CFrame.Angles(math.rad(-viewmodel.Recoil * 4), 0, 0)
+
+	local reloadPose, leftHandPose = getReloadMotion()
+	local targetMotion = idle * bob * sprintPose * wallPose * reloadPose
+	viewmodel.Motion = viewmodel.Motion:Lerp(targetMotion, expAlpha(14, dt))
+	viewmodel.LeftHandMotion = viewmodel.LeftHandMotion:Lerp(
+		leftHandPose,
+		expAlpha(18, dt)
+	)
+	viewmodel.WeaponMotor.Transform = viewmodel.Motion * sway * recoil
+	viewmodel.LeftHandMotor.Transform = viewmodel.LeftHandMotion
+end
+
+UserInputService.InputBegan:Connect(function(input, processed)
+	if not processed and input.KeyCode == Enum.KeyCode.LeftShift then
+		sprintHeld = true
+	end
+end)
+
+UserInputService.InputEnded:Connect(function(input)
+	if input.KeyCode == Enum.KeyCode.LeftShift then
+		sprintHeld = false
+	end
+end)
+
+ViewmodelState.OnRecoil(function(weaponType)
+	if not viewmodel then return end
+	local strength = RECOIL_STRENGTH[weaponType] or 0.7
+	viewmodel.RecoilVelocity = math.clamp(
+		viewmodel.RecoilVelocity + (7 * strength),
+		-12,
+		12
+	)
+end)
+
+ReloadStateChanged.OnClientEvent:Connect(function(active, duration)
+	reloadActive = active == true
+	if reloadActive then
+		reloadStartedAt = os.clock()
+		reloadDuration = math.max(duration or 0, 0.1)
+	else
+		reloadDuration = 0
+	end
+end)
+
+RunService:BindToRenderStep(
+	VIEWMODEL_RENDER_STEP,
+	Enum.RenderPriority.Camera.Value + 1,
+	updateViewmodel
+)

--- a/src/StarterPlayerScripts/FirstPersonViewmodel.lua
+++ b/src/StarterPlayerScripts/FirstPersonViewmodel.lua
@@ -53,6 +53,11 @@ local ARM_PARTS = {
 	RightLowerArm = true,
 	RightHand = true,
 }
+local INTERACTIVE_UIS = {
+	ShopUI = true,
+	DailyQuestUI = true,
+	TrainingArenaUI = true,
+}
 local RECOIL_STRENGTH = {
 	Pistol = 1.0,
 	SMG = 0.55,
@@ -112,27 +117,48 @@ local function cloneLimb(source, name, scale)
 	return limb
 end
 
-local function setRealPartsHidden(character, tool, hidden)
-	if character then
-		for partName in pairs(ARM_PARTS) do
-			local part = character:FindFirstChild(partName)
-			if part and part:IsA("BasePart") then
-				part.LocalTransparencyModifier = hidden and 1 or 0
-			end
+local function collectRealParts(character, tool)
+	local armParts = {}
+	for partName in pairs(ARM_PARTS) do
+		local part = character:FindFirstChild(partName)
+		if part and part:IsA("BasePart") then
+			table.insert(armParts, part)
 		end
 	end
-	if tool then
-		for _, descendant in ipairs(tool:GetDescendants()) do
-			if descendant:IsA("BasePart") then
-				descendant.LocalTransparencyModifier = hidden and 1 or 0
-			end
+
+	local toolParts = {}
+	for _, descendant in ipairs(tool:GetDescendants()) do
+		if descendant:IsA("BasePart") then
+			table.insert(toolParts, descendant)
+		end
+	end
+	return armParts, toolParts
+end
+
+local function setPartsHidden(parts, hidden)
+	for _, part in ipairs(parts) do
+		if part.Parent then
+			part.LocalTransparencyModifier = hidden and 1 or 0
 		end
 	end
 end
 
+local function isInteractiveUIOpen()
+	local playerGui = player:FindFirstChildOfClass("PlayerGui")
+	if not playerGui then return false end
+	for name in pairs(INTERACTIVE_UIS) do
+		local gui = playerGui:FindFirstChild(name)
+		if gui and gui:IsA("ScreenGui") and gui.Enabled then
+			return true
+		end
+	end
+	return false
+end
+
 local function destroyViewmodel()
 	if not viewmodel then return end
-	setRealPartsHidden(viewmodel.Character, viewmodel.SourceTool, false)
+	setPartsHidden(viewmodel.RealArmParts, false)
+	setPartsHidden(viewmodel.RealToolParts, false)
 	ViewmodelState.SetActiveMuzzle(nil)
 	if viewmodel.Model then viewmodel.Model:Destroy() end
 	viewmodel = nil
@@ -209,7 +235,9 @@ local function buildViewmodel(character, sourceTool)
 		return
 	end
 	for _, descendant in ipairs(model:GetDescendants()) do
-		if descendant:IsA("BasePart") and descendant ~= root then
+		if descendant:IsA("BaseScript") then
+			descendant:Destroy()
+		elseif descendant:IsA("BasePart") and descendant ~= root then
 			preparePart(descendant)
 			if sourceTool.Name == "Viper Aurum"
 				and descendant.Name ~= "Barrel"
@@ -262,6 +290,7 @@ local function buildViewmodel(character, sourceTool)
 	local rayParams = RaycastParams.new()
 	rayParams.FilterType = Enum.RaycastFilterType.Exclude
 	rayParams.FilterDescendantsInstances = { character, model }
+	local realArmParts, realToolParts = collectRealParts(character, sourceTool)
 
 	ViewmodelState.SetActiveMuzzle(handle:FindFirstChild("Muzzle"))
 	viewmodel = {
@@ -279,19 +308,24 @@ local function buildViewmodel(character, sourceTool)
 		Recoil = 0,
 		RecoilVelocity = 0,
 		RayParams = rayParams,
+		RealArmParts = realArmParts,
+		RealToolParts = realToolParts,
 	}
-	setRealPartsHidden(character, sourceTool, true)
+	setPartsHidden(realArmParts, true)
+	setPartsHidden(realToolParts, true)
 end
 
 local function isFirstPerson(character)
 	local camera = workspace.CurrentCamera
 	local head = character and character:FindFirstChild("Head")
-	if not camera or not head then return false end
+	if not camera or not head or isInteractiveUIOpen() then return false end
 	local distanceThreshold = viewmodel
 		and FIRST_PERSON_EXIT_DISTANCE
 		or FIRST_PERSON_ENTER_DISTANCE
+	-- Interactive menus release both locks before this frame is rendered.
 	return player.CameraMode == Enum.CameraMode.LockFirstPerson
-		or (camera.CFrame.Position - head.Position).Magnitude < distanceThreshold
+		or (UserInputService.MouseBehavior == Enum.MouseBehavior.LockCenter
+			and (camera.CFrame.Position - head.Position).Magnitude < distanceThreshold)
 end
 
 local function getReloadMotion()
@@ -345,7 +379,8 @@ local function updateViewmodel(dt)
 
 	local camera = workspace.CurrentCamera
 	viewmodel.Model:PivotTo(camera.CFrame)
-	setRealPartsHidden(character, sourceTool, true)
+	setPartsHidden(viewmodel.RealArmParts, true)
+	setPartsHidden(viewmodel.RealToolParts, true)
 
 	local moving = humanoid.MoveDirection.Magnitude > 0.1
 		and humanoid.FloorMaterial ~= Enum.Material.Air

--- a/src/StarterPlayerScripts/ViewmodelController.lua
+++ b/src/StarterPlayerScripts/ViewmodelController.lua
@@ -1,43 +1,241 @@
 -- ViewmodelController.lua (StarterPlayerScripts)
--- First-person quality-of-life: force arms visible.
+-- Client-side, non-physical third-person R15 weapon hold.
 --
--- LockFirstPerson hides body parts via LocalTransparencyModifier; we re-set
--- the arm parts to 0 each frame so the player sees their own hands holding
--- the gun.
---
--- Server-side off-hand IK is currently disabled in WeaponMeshes (#56) because
--- its rigid grip solver dragged character RootParts. This script only keeps
--- the real character arms visible in first-person; it does not restore the
--- two-hand pose.
+-- Every client applies the pose to every visible player so Transform state does
+-- not need server replication. FirstPersonViewmodel owns the local camera rig.
+-- The old physical server solver stays disabled because it moved RootParts.
 
 local Players = game:GetService("Players")
-local RunService = game:GetService("RunService")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
 
 local player = Players.LocalPlayer
+local R15Pose = require(ReplicatedStorage:WaitForChild("R15Pose"))
+local ReloadStateChanged = ReplicatedStorage:WaitForChild("GameEvents")
+	:WaitForChild("ReloadStateChanged")
 
-local ARM_PARTS = {
-	"LeftUpperArm", "LeftLowerArm", "LeftHand",
-	"RightUpperArm", "RightLowerArm", "RightHand",
+local RELOAD_ATTRIBUTE = "FinalStrikeReloading"
+local HOLD_BLEND_TIME = 0.12
+local HOLD_RESUME_DELAY = 0.1
+local POSE_JOINT_NAMES = {
+	RightShoulder = true,
+	RightElbow = true,
+	RightWrist = true,
+	LeftShoulder = true,
+	LeftElbow = true,
+	LeftWrist = true,
 }
+local playerStates = {}
+local localReloadActive = false
 
-local function watchCharacter(char)
-	local arms = {}
-	for _, name in ipairs(ARM_PARTS) do
-		local p = char:WaitForChild(name, 5)
-		if p then table.insert(arms, p) end
+local function disconnectAll(connections)
+	for _, connection in ipairs(connections) do
+		connection:Disconnect()
 	end
+	table.clear(connections)
+end
 
-	local conn = RunService.RenderStepped:Connect(function()
-		if player.CameraMode == Enum.CameraMode.LockFirstPerson then
-			for _, p in ipairs(arms) do
-				p.LocalTransparencyModifier = 0
+local function findTwoHandedTool(character)
+	for _, child in ipairs(character:GetChildren()) do
+		if child:IsA("Tool") then
+			local handle = child:FindFirstChild("Handle")
+			local leftGrip = handle and handle:FindFirstChild("LeftGrip")
+			if leftGrip and leftGrip:IsA("Attachment") then
+				return child
 			end
 		end
-	end)
-	char.AncestryChanged:Connect(function(_, parent)
-		if not parent then conn:Disconnect() end
+	end
+	return nil
+end
+
+local function stopHold(characterState, destroy)
+	characterState.RefreshGeneration += 1
+	if not characterState.PoseController then return end
+
+	if destroy then
+		characterState.PoseController:Destroy()
+		characterState.PoseController = nil
+	else
+		characterState.PoseController:Stop()
+	end
+end
+
+local function refreshHold(owner, characterState)
+	local character = characterState.Character
+	if characterState.Dead or character.Parent == nil then
+		stopHold(characterState, true)
+		return
+	end
+
+	local reloading = owner:GetAttribute(RELOAD_ATTRIBUTE) == true
+		or (owner == player and localReloadActive)
+	if reloading or not findTwoHandedTool(character) then
+		stopHold(characterState, false)
+		return
+	end
+
+	local humanoid = character:FindFirstChildOfClass("Humanoid")
+	if not humanoid or humanoid.RigType ~= Enum.HumanoidRigType.R15 then
+		stopHold(characterState, true)
+		return
+	end
+
+	if not characterState.PoseController then
+		local controller = R15Pose.new(character)
+		if not controller:IsSupported() then
+			controller:Destroy()
+			if not characterState.UnsupportedWarningPending then
+				characterState.UnsupportedWarningPending = true
+				task.delay(1, function()
+					characterState.UnsupportedWarningPending = false
+					if not characterState.Dead
+						and characterState.Character.Parent
+						and not characterState.PoseController
+						and findTwoHandedTool(characterState.Character)
+					then
+						warn("Two-hand pose requires an R15 character with both shoulder joints")
+					end
+				end)
+			end
+			return
+		end
+		characterState.PoseController = controller
+	end
+
+	characterState.PoseController:SetPersistentPose(R15Pose.Poses.TwoHandHold, HOLD_BLEND_TIME)
+end
+
+local function scheduleRefresh(owner, characterState, delaySeconds)
+	characterState.RefreshGeneration += 1
+	local generation = characterState.RefreshGeneration
+	task.delay(delaySeconds or 0, function()
+		if characterState.RefreshGeneration == generation then
+			refreshHold(owner, characterState)
+		end
 	end)
 end
 
-if player.Character then watchCharacter(player.Character) end
-player.CharacterAdded:Connect(watchCharacter)
+local function cleanupCharacterState(characterState)
+	if not characterState then return end
+	characterState.Dead = true
+	stopHold(characterState, true)
+	disconnectAll(characterState.Connections)
+end
+
+local function watchCharacter(owner, ownerState, character)
+	cleanupCharacterState(ownerState.CharacterState)
+	if owner == player then
+		localReloadActive = owner:GetAttribute(RELOAD_ATTRIBUTE) == true
+	end
+
+	local characterState = {
+		Character = character,
+		Connections = {},
+		PoseController = nil,
+		RefreshGeneration = 0,
+		Dead = false,
+	}
+	ownerState.CharacterState = characterState
+
+	local function bindHumanoid(child)
+		if not child:IsA("Humanoid") or characterState.Humanoid then return end
+		characterState.Humanoid = child
+		table.insert(characterState.Connections, child.Died:Connect(function()
+			characterState.Dead = true
+			stopHold(characterState, true)
+		end))
+	end
+	for _, child in ipairs(character:GetChildren()) do
+		bindHumanoid(child)
+	end
+
+	table.insert(characterState.Connections, character.ChildAdded:Connect(function(child)
+		bindHumanoid(child)
+		if child:IsA("Tool") or child:IsA("Humanoid") then
+			scheduleRefresh(owner, characterState)
+		end
+	end))
+	table.insert(characterState.Connections, character.ChildRemoved:Connect(function(child)
+		if child:IsA("Tool") then
+			scheduleRefresh(owner, characterState)
+		end
+	end))
+	table.insert(characterState.Connections, character.DescendantAdded:Connect(function(descendant)
+		local isPoseJoint = POSE_JOINT_NAMES[descendant.Name]
+			and (descendant:IsA("Motor6D") or descendant:IsA("AnimationConstraint"))
+		if descendant.Name == "LeftGrip" or isPoseJoint then
+			if isPoseJoint and characterState.PoseController then
+				stopHold(characterState, true)
+			end
+			scheduleRefresh(owner, characterState)
+		end
+	end))
+	table.insert(characterState.Connections, character.AncestryChanged:Connect(function(_, parent)
+		if not parent then cleanupCharacterState(characterState) end
+	end))
+
+	refreshHold(owner, characterState)
+end
+
+local function watchPlayer(owner)
+	if playerStates[owner] then return end
+
+	local ownerState = {
+		Connections = {},
+		CharacterState = nil,
+	}
+	playerStates[owner] = ownerState
+
+	table.insert(ownerState.Connections, owner.CharacterAdded:Connect(function(character)
+		watchCharacter(owner, ownerState, character)
+	end))
+	table.insert(ownerState.Connections, owner.CharacterRemoving:Connect(function(character)
+		local characterState = ownerState.CharacterState
+		if characterState and characterState.Character == character then
+			cleanupCharacterState(characterState)
+			ownerState.CharacterState = nil
+		end
+	end))
+	table.insert(ownerState.Connections, owner:GetAttributeChangedSignal(RELOAD_ATTRIBUTE):Connect(function()
+		local characterState = ownerState.CharacterState
+		if not characterState then return end
+
+		if owner:GetAttribute(RELOAD_ATTRIBUTE) == true then
+			stopHold(characterState, false)
+			return
+		end
+
+		scheduleRefresh(owner, characterState, HOLD_RESUME_DELAY)
+	end))
+
+	if owner.Character then
+		watchCharacter(owner, ownerState, owner.Character)
+	end
+end
+
+local function unwatchPlayer(owner)
+	local ownerState = playerStates[owner]
+	if not ownerState then return end
+	cleanupCharacterState(ownerState.CharacterState)
+	disconnectAll(ownerState.Connections)
+	playerStates[owner] = nil
+end
+
+for _, owner in ipairs(Players:GetPlayers()) do
+	watchPlayer(owner)
+end
+Players.PlayerAdded:Connect(watchPlayer)
+Players.PlayerRemoving:Connect(unwatchPlayer)
+
+-- Stop immediately in the same turn WeaponClient begins its authoritative
+-- reload. The replicated Player attribute handles cross-client resume.
+ReloadStateChanged.OnClientEvent:Connect(function(active)
+	localReloadActive = active == true
+	local ownerState = playerStates[player]
+	local characterState = ownerState and ownerState.CharacterState
+	if not characterState then return end
+	if localReloadActive then
+		stopHold(characterState, false)
+	else
+		scheduleRefresh(player, characterState)
+	end
+end)

--- a/src/StarterPlayerScripts/ViewmodelController.lua
+++ b/src/StarterPlayerScripts/ViewmodelController.lua
@@ -3,7 +3,7 @@
 --
 -- Every client applies the pose to every visible player so Transform state does
 -- not need server replication. FirstPersonViewmodel owns the local camera rig.
--- The old physical server solver stays disabled because it moved RootParts.
+-- The physical server solver stays disabled because it moved RootParts.
 
 local Players = game:GetService("Players")
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
@@ -204,7 +204,11 @@ local function watchPlayer(owner)
 			return
 		end
 
-		scheduleRefresh(owner, characterState, HOLD_RESUME_DELAY)
+		scheduleRefresh(
+			owner,
+			characterState,
+			owner == player and 0 or HOLD_RESUME_DELAY
+		)
 	end))
 
 	if owner.Character then

--- a/src/StarterPlayerScripts/WeaponClient.lua
+++ b/src/StarterPlayerScripts/WeaponClient.lua
@@ -15,6 +15,7 @@ local camera = workspace.CurrentCamera
 
 local GameConfig = require(ReplicatedStorage:WaitForChild("GameConfig"))
 local R15Pose = require(ReplicatedStorage:WaitForChild("R15Pose"))
+local ViewmodelState = require(ReplicatedStorage:WaitForChild("ViewmodelState"))
 local events = ReplicatedStorage:WaitForChild("GameEvents")
 
 local FireWeapon = events:WaitForChild("FireWeapon")
@@ -299,7 +300,8 @@ local function fireWeapon()
 
 	-- Local muzzle flash for the local player (server's WeaponHit handles the
 	-- impact spark; this is the gun-end of the shot).
-	spawnMuzzleFlash(muzzle)
+	spawnMuzzleFlash(ViewmodelState.GetActiveMuzzle() or muzzle)
+	ViewmodelState.EmitRecoil(config.Type)
 
 	if config.Type == "Knife" then
 		-- Melee: short range check

--- a/workloads/15-fps-viewmodel.yaml
+++ b/workloads/15-fps-viewmodel.yaml
@@ -48,6 +48,7 @@ camera_states:
 interactive_uis_set:
   - ShopUI
   - DailyQuestUI
+  - TrainingArenaUI
 
 mouse_release_enforcement:
   rationale: |
@@ -67,7 +68,8 @@ viewmodel_arms:
     CurrentCamera.CFrame。它 clone 裝備中的 Tool mesh 與左右 R15 Hand，以
     WeaponMotor / RightHandMotor / LeftHandMotor 連接；weapon 原有 WeldConstraint
     也轉成 local Motor6D。真實角色手臂與 Tool 僅用 LocalTransparencyModifier
-    在本機隱藏，其他玩家仍看到 server Tool 與完整第三人稱角色。
+    在本機隱藏，其他玩家仍看到 server Tool 與完整第三人稱角色。真實 parts
+    在建構時快取，clone 中的 BaseScript 會移除，RenderStepped 不重掃 descendants。
   motion:
     - "低幅 idle sway + mouse sway"
     - "落地移動時 walk bob；LeftShift+moving 時 visual-only sprint pose"
@@ -90,6 +92,16 @@ third_person_two_hand_grip:
     MatchManager 的 server-owned FinalStrikeReloading attribute 會在 reload 期間暫停
     normal hold，讓 published clip / procedural fallback 單獨控制 arm joints。
   single_handed: "Pistol / Knife 沒有 LeftGrip，因此不套 TwoHandHold"
+  two_client_e2e_2026_07_12:
+    topology: "StudioTestService Server & Clients，2 Players；Player1 shooter、Player2 remote observer"
+    idle: "observer LeftHand→LeftGrip 0.00663 studs；0 physical off-hand constraints"
+    run: "observer 在 16.01 studs/s、MoveDirection=1 時 gap 0.00663 studs"
+    jump_freefall: "observer 看到 7.20-stud jump arc、17.47 studs/s upward velocity、Freefall→Landed；max gap 0.00664 studs"
+    stationary_safety: "1.5s observer horizontal drift 0.00086 studs；無 RootPart propulsion"
+    reload: "FinalStrikeReloading=true 時 gap 2.942 studs（hold released）；false 後恢復 0.00663 studs"
+    local_reload_resume: "server attribute→RemoteEvent finish order下，第3 frame gap 0.0443、第8 frame 0.00663；無額外 0.1s rest-pose dead time"
+    single_handed: "observer 對 Viper Mk1 / Fang Scout 均看到 no LeftGrip、0 off-hand constraints"
+    golden_viper: "shooter camera-local ViewModel 有左右手、3 個 Motor6D、2 個 gold parts；0 BaseScripts / 0 physical constraints"
 
 reload_animation:
   authoritative_timing: "MatchManager 提供 ReloadTime；client clip 依該 duration 調速"

--- a/workloads/15-fps-viewmodel.yaml
+++ b/workloads/15-fps-viewmodel.yaml
@@ -1,7 +1,7 @@
 name: FPSViewmodel
 owner: claude-code
 priority: P1-polish
-status: "⚠️ PARTIAL (#39 two-hand hold remains open; #47 reload E2E passed 2026-07-12)"
+status: "✅ COMPLETE (#39 non-physical two-hand hold; #47 reload E2E passed 2026-07-12)"
 backfill_receipt: receipts/sprint-8-shop-economy-fps.md
 backfill_note: |
   此 contract 為 Sprint 8a 衛生補課產出。實際實作分散在 main 多個 commits：
@@ -17,9 +17,13 @@ purpose: |
   比賽中第一人稱（FPS）視角體驗：
   1. CameraController 鎖第一人稱 + 鎖定鼠標到中心（PvE/PvPWarning/PvP）；
      大廳 / 觀戰時釋放回三人稱 + 自由鼠標。
-  2. ViewmodelController 強制手臂可見（覆蓋 LockFirstPerson 預設隱藏）；
-     WeaponClient 播放已發布的 R15 reload animation，無匹配 clip 時使用程序化姿勢。
-  3. crosshair-aligned aim：raycast 從 viewport center 出，bullet 對齊準心
+  2. FirstPersonViewmodel 在 CurrentCamera 下建立 local-only 雙手 + 武器
+     Motor6D rig；ViewmodelController 則在所有 client 為真實第三人稱角色維持
+     non-physical R15 TwoHandHold。兩層分工，避免多個 controller 同時寫相同 joints。
+  3. WeaponClient 播放已發布的真實角色 R15 reload animation，無匹配 clip
+     時使用程序化姿勢；camera ViewModel 依相同 authoritative reload timing
+     播放自己的 Motor6D reload motion。
+  4. crosshair-aligned aim：raycast 從 viewport center 出，bullet 對齊準心
      而非 muzzle 方向（修正 #5/6/7）。
 
 # ============= 規格 =============
@@ -58,15 +62,34 @@ mouse_release_enforcement:
     - else: 不 enforce，讓 CameraScript 自管（right-click drag、click-to-move）
 
 viewmodel_arms:
-  rationale: "LockFirstPerson 設 LocalTransparencyModifier=1 隱藏所有 body parts，玩家看不到自己的手"
-  fix: "RenderStepped 強制 6 個 arm parts (Left/Right Upper/Lower/Hand) LocalTransparencyModifier=0"
+  architecture: |
+    FirstPersonViewmodel 每個 RenderStepped 將 anchored transparent root PivotTo
+    CurrentCamera.CFrame。它 clone 裝備中的 Tool mesh 與左右 R15 Hand，以
+    WeaponMotor / RightHandMotor / LeftHandMotor 連接；weapon 原有 WeldConstraint
+    也轉成 local Motor6D。真實角色手臂與 Tool 僅用 LocalTransparencyModifier
+    在本機隱藏，其他玩家仍看到 server Tool 與完整第三人稱角色。
+  motion:
+    - "低幅 idle sway + mouse sway"
+    - "落地移動時 walk bob；LeftShift+moving 時 visual-only sprint pose"
+    - "每次 local shot 透過 ViewmodelState 加入 spring recoil"
+    - "ReloadStateChanged authoritative duration 驅動 weapon/left-hand reload phases"
+    - "camera forward raycast 在牆前下壓並拉回 ViewModel，避免穿牆"
+  presentation: |
+    所有武器共用這個 ViewModel。真實武器品牌名稱不進入遊戲；
+    Viper Aurum 作為 Golden Viper（金色手槍）呈現，第一人稱用雙手握持。
+    第三人稱 Pistol / Knife 仍維持單手。
 
-left_hand_ik:
-  state: disabled
+third_person_two_hand_grip:
+  state: "server physical solver disabled; client animation pose active"
   reason: |
     舊 server-side grip solver 會透過物理 constraint 拖動 HumanoidRootPart，
-    造成玩家與 NPC 漂移（#56）。ViewmodelController 目前只維持手臂可見。
-  open_issue: "#39 — non-propulsive two-hand hold pose"
+    造成玩家與 NPC 漂移（#56），因此永久保持 disabled。
+  replacement: |
+    ViewmodelController 在每個 client 監看所有 player character；Tool.Handle.LeftGrip
+    存在時以 R15Pose persistent PreSimulation transform 維持 TwoHandHold。
+    MatchManager 的 server-owned FinalStrikeReloading attribute 會在 reload 期間暫停
+    normal hold，讓 published clip / procedural fallback 單獨控制 arm joints。
+  single_handed: "Pistol / Knife 沒有 LeftGrip，因此不套 TwoHandHold"
 
 reload_animation:
   authoritative_timing: "MatchManager 提供 ReloadTime；client clip 依該 duration 調速"
@@ -94,14 +117,23 @@ crosshair_aligned_aim:
 
 artifacts:
   - src/StarterPlayerScripts/CameraController.lua  (130 行 — 主控)
-  - src/StarterPlayerScripts/ViewmodelController.lua  (arms 可見)
-  - src/StarterPlayerScripts/WeaponClient.lua  (crosshair aim + reload animation/fallback)
+  - src/StarterPlayerScripts/FirstPersonViewmodel.lua  (camera-local Motor6D hands + weapon)
+  - src/StarterPlayerScripts/ViewmodelController.lua  (all-player third-person two-hand pose)
+  - src/StarterPlayerScripts/WeaponClient.lua  (crosshair aim + reload + local recoil/muzzle)
   - src/ReplicatedStorage/R15Pose.lua  (non-physical upper-body pose controller)
+  - src/ReplicatedStorage/ViewmodelState.lua  (local-only recoil + active muzzle state)
   - src/StarterPlayerScripts/HUDController.lua  (crosshair ScreenGui FinalStrikeCrosshair)
   - src/ServerScriptService/MatchManager.lua  (FireWeapon handler 接收 client crosshair-aligned direction)
 
 success_criteria:
-  - "比賽中鎖第一人稱，玩家看到自己的手 + 武器"
+  - "比賽中鎖第一人稱，CurrentCamera 下有 local-only ViewModel、左右 R15 Hand 與武器"
+  - "ViewModel 每個 RenderStepped 精確跟 camera，並有 idle sway / walk bob / sprint / recoil / reload / wall pushback"
+  - "第一人稱隱藏真實本機手臂與 Tool；退出第一人稱、死亡、換槍、重生時完整還原與清理"
+  - "Viper Aurum 以 Golden Viper 金色外觀、第一人稱雙手握持；真實品牌名稱不使用"
+  - "SMG / Rifle / Shotgun / Sniper / Minigun 在 idle / run / jump / freefall / land 維持雙手 pose"
+  - "Pistol / Knife 維持單手；切槍、死亡、重生、character removal 不殘留 pose controller"
+  - "reload 期間 normal hold 暫停，結束或取消後恢復，沒有 controller 互搶"
+  - "two-hand pose 不建立 physical grip constraint、不寫 HumanoidRootPart，stationary 無漂移"
   - "Pistol / Rifle / Shotgun 使用對應、由 Final Strike owner 發布的 R15 reload clip"
   - "SMG / Sniper / Minigun 使用程序化 reload fallback，不冒用錯誤武器 clip"
   - "reload 取消或換槍時不殘留 AnimationTrack / R15Pose task"
@@ -110,6 +142,7 @@ success_criteria:
   - "被淘汰玩家切回三人稱觀戰（#11）"
   - "Bullet 從螢幕中心發射對齊 crosshair（不是從 muzzle 偏右）"
   - "大廳 / Match End 階段釋放鼠標"
+  - "camera ViewModel 僅含 anchored root + non-physical parts/Motor6D；不新增任何物理 grip constraint"
 
 recovery:
   - "鼠標卡 LockCenter 點不到 UI → releaseEnforceUntil 機制 / interactive_uis_set 是否註冊"
@@ -117,12 +150,13 @@ recovery:
   - "reload clip 不播放 → 檢查 GameConfig ID ownership；client 會預載，60 frames 仍未 ready 才切 fallback"
   - "reload pose 殘留 → 檢查 ReloadStateChanged(false) 與 reloadGeneration cancellation"
   - "Bullet 不對齊 crosshair → WeaponClient raycast origin 是否改成 camera center"
+  - "第一人稱武器不見 → 檢查 CurrentCamera.FinalStrikeViewModel、裝備 Tool、CameraMode 與 ViewmodelState muzzle"
+  - "牆前穿模 → 檢查 ViewModel raycast exclude list 與 wall pushback Transform"
 
 # ============= 已知限制 / Sprint 8b+ 候選 =============
 known_limitations:
   - "muzzle flash 仍 client-only（Sprint 7 lesson）— 跨玩家可見要 server-side flash event"
   - "Crosshair 是 4-segment open-center（commit d054043 CEO spec），未對應稀有度顏色"
-  - "一般持槍時的非物理雙手 pose 尚未接回；#39 保持 open"
 
 # ============= 依賴 =============
 dependencies:
@@ -132,4 +166,5 @@ dependencies:
   events_observed:
     - PhaseChanged
     - PlayerEliminated
+    - ReloadStateChanged
     - GUI Enabled changes (ShopUI / DailyQuestUI)


### PR DESCRIPTION
## Summary
- add a camera-local R15 first-person ViewModel with two visible hands, Motor6D weapon alignment, sway, walk bob, sprint, recoil, reload motion, and wall pushback
- keep real third-person R15 characters on a persistent non-physical two-hand pose through movement and airborne states while preserving single-handed Pistol/Knife behavior
- give reload animation temporary joint ownership, then restore the hold after completion, cancellation, switching, death, respawn, and camera replacement
- present Viper Aurum as the fictional Golden Viper instead of using a real weapon name

## Safety
- creates no physical off-hand solver and never writes HumanoidRootPart
- existing `WeaponMeshes` `WeldConstraint`s only assemble weapon model parts; the grip path adds no off-hand `WeldConstraint`, `AlignPosition`, `AlignOrientation`, `IKControl`, or other physical constraint
- keeps the first-person rig local, anchored, non-collidable, non-touchable, non-queryable, massless, and shadowless
- strips cloned `BaseScript`s before the ViewModel enters `CurrentCamera`
- leaves server-authoritative firing, hit validation, ammo, reload timing, and the disabled #56 solver unchanged

## Verification
- **real Studio Server & Clients test with 2 players:** Player2 observed Player1 holding `Phantom Ranger` at 0.00663-stud LeftHand-to-LeftGrip distance while idle
- remote run: 16.01 studs/s, `MoveDirection=1`, gap 0.00663 studs
- remote jump arc: 7.20-stud height gain, 17.47 studs/s upward velocity, Freefall → Landed, maximum gap 0.00664 studs
- stationary safety: 0.00086-stud horizontal drift over 1.5 seconds and zero physical off-hand constraints
- replicated reload ownership: `FinalStrikeReloading=true` released the hold to 2.942 studs; `false` restored it to 0.00663 studs; local owner reached 0.00663 by frame 8 with no extra 0.1-second rest-pose delay
- remote Pistol/Knife: `Viper Mk1` and `Fang Scout` had no `LeftGrip` and remained single-handed with zero off-hand constraints
- Golden Viper first person: two hands, `WeaponMotor` + both hand Motor6Ds, two gold weapon parts, zero cloned scripts, and zero physical constraints
- actual B/Q input opened Shop/Daily Quest with `MouseBehavior=Default` and removed the ViewModel; closing restored `LockFirstPerson`, `LockCenter`, and the ViewModel
- verified recoil/reload transforms, sprint/walk bob, wall pushback and recovery, camera replacement rebuild, real-tool visibility restoration, and zero product console errors
- final diff and follow-up lifecycle fixes passed pre-landing and adversarial review with no unresolved high-confidence findings

Closes #39